### PR TITLE
Enable HTTP redirect handling in   MCP client transport

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -50,7 +50,8 @@ public distinct isolated client class Client {
     # + return - ClientError if initialization fails, nil on success
     public isolated function init(string serverUrl, *ClientConfiguration config) returns ClientError? {
         // Create and initialize transport.
-        StreamableHttpClientTransport newTransport = check new (serverUrl);
+        ClientConfiguration {info: _, capabilityConfig: _, ...transportConfig} = config;
+        StreamableHttpClientTransport newTransport = check new (serverUrl, transportConfig);
         self.transport = newTransport;
 
         string? sessionId = newTransport.getSessionId();
@@ -93,7 +94,7 @@ public distinct isolated client class Client {
         self.serverInfo = response.serverInfo.cloneReadOnly();
 
         // Send notification to complete initialization.
-        check self.sendNotificationMessage(<InitializedNotification> {});
+        check self.sendNotificationMessage(<InitializedNotification>{});
     }
 
     # Opens a server-sent events (SSE) stream for asynchronous server-to-client communication.


### PR DESCRIPTION
## Purpose
Enable automatic HTTP redirect handling in the MCP client by configuring the underlying HTTP client to follow redirects by default.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
