### PR TITLE
Make mcp client info optional with a default value

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.1"
+version = "2.14.2"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.2"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/streamable_http_client.bal
+++ b/ballerina/streamable_http_client.bal
@@ -39,7 +39,7 @@ public distinct isolated client class StreamableHttpClient {
     # + clientInfo - Client implementation information
     # + capabilities - Client capabilities to advertise
     # + return - `ClientError` if initialization fails, `()` on success
-    isolated remote function initialize(Implementation clientInfo, ClientCapabilities capabilities = {})
+    isolated remote function initialize(Implementation? clientInfo, ClientCapabilities capabilities = {})
             returns ClientError? {
         lock {
             string? sessionId = self.transport.getSessionId();
@@ -55,7 +55,10 @@ public distinct isolated client class StreamableHttpClient {
             params: {
                 protocolVersion: LATEST_PROTOCOL_VERSION,
                 capabilities: capabilities,
-                clientInfo: clientInfo
+                clientInfo: clientInfo ?: {
+                    name: "MCP Client",
+                    version: "1.0.0"
+                }
             }
         };
 

--- a/ballerina/streamable_http_client.bal
+++ b/ballerina/streamable_http_client.bal
@@ -39,8 +39,8 @@ public distinct isolated client class StreamableHttpClient {
     # + clientInfo - Client implementation information
     # + capabilities - Client capabilities to advertise
     # + return - `ClientError` if initialization fails, `()` on success
-    isolated remote function initialize(Implementation? clientInfo, ClientCapabilities capabilities = {})
-            returns ClientError? {
+    isolated remote function initialize(Implementation clientInfo = {name: "MCP Client", version: "1.0.0"},
+            ClientCapabilities capabilities = {}) returns ClientError? {
         lock {
             string? sessionId = self.transport.getSessionId();
 
@@ -55,10 +55,7 @@ public distinct isolated client class StreamableHttpClient {
             params: {
                 protocolVersion: LATEST_PROTOCOL_VERSION,
                 capabilities: capabilities,
-                clientInfo: clientInfo ?: {
-                    name: "MCP Client",
-                    version: "1.0.0"
-                }
+                clientInfo: clientInfo
             }
         };
 


### PR DESCRIPTION
## Purpose
$title

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
