### PR TITLE
Implement passing `mcp:Meta`

### DIFF
--- a/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.11"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -256,7 +256,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -301,7 +301,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -326,7 +326,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.8.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/ballerina-tests/mcp-ballerina-tests/tests/advanced_meta_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/advanced_meta_tests.bal
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+import ballerina/test;
+
+// An mcp:AdvancedService builds the whole CallToolResult, so it can attach server-originated
+// response _meta regardless of whether the client sent request _meta.
+listener mcp:Listener advancedMetaListener = check new (8768);
+
+@mcp:ServiceConfig {
+    info: {name: "advanced-meta-test-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+service mcp:AdvancedService /mcp on advancedMetaListener {
+
+    remote isolated function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {
+            tools: [
+                {
+                    name: "ping",
+                    description: "Returns a fixed response with server-originated metadata",
+                    inputSchema: {"type": "object", "properties": {}}
+                }
+            ]
+        };
+    }
+
+    remote isolated function onCallTool(mcp:CallToolParams params, mcp:Session? session)
+            returns mcp:CallToolResult|mcp:ServerError {
+        // Server-originated metadata, independent of the request.
+        record {} responseMeta = {"serverId": "srv-1"};
+
+        // Optionally fold in a client-supplied key, if present.
+        if params._meta is record {} {
+            record {} clientMeta = <record {}>params._meta;
+            anydata traceId = clientMeta["traceId"];
+            if traceId !is () {
+                responseMeta["traceId"] = traceId;
+            }
+        }
+
+        return {
+            content: [{'type: "text", text: "pong"}],
+            _meta: responseMeta
+        };
+    }
+}
+
+final mcp:StreamableHttpClient advancedMetaClient = check new ("http://localhost:8768/mcp");
+final mcp:Implementation advancedMetaClientInfo = {name: "advanced-meta-test-client", version: "1.0.0"};
+
+@test:Config
+function testAdvancedServiceOriginatesResponseMetaWithoutRequestMeta() returns error? {
+    check advancedMetaClient->initialize(advancedMetaClientInfo);
+
+    // The client sends no _meta, yet the server attaches its own response _meta.
+    mcp:CallToolResult result = check advancedMetaClient->callTool({name: "ping"});
+
+    test:assertTrue(result._meta is record {},
+            msg = "AdvancedService must be able to originate response _meta with no request _meta");
+    record {} responseMeta = check result._meta.ensureType();
+    test:assertEquals(responseMeta["serverId"], "srv-1");
+    test:assertFalse(responseMeta.hasKey("traceId"),
+            msg = "No client meta was sent, so no client-derived key should appear");
+}
+
+@test:Config {dependsOn: [testAdvancedServiceOriginatesResponseMetaWithoutRequestMeta]}
+function testAdvancedServiceReadsRequestMetaAndReturnsOwn() returns error? {
+    mcp:CallToolResult result = check advancedMetaClient->callTool({
+        name: "ping",
+        _meta: {"traceId": "trace-xyz"}
+    });
+
+    record {} responseMeta = check result._meta.ensureType();
+    test:assertEquals(responseMeta["serverId"], "srv-1",
+            msg = "Server-originated _meta must be present");
+    test:assertEquals(responseMeta["traceId"], "trace-xyz",
+            msg = "AdvancedService must be able to read request _meta via params._meta");
+}

--- a/ballerina-tests/mcp-ballerina-tests/tests/meta_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/meta_tests.bal
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+import ballerina/test;
+
+listener mcp:Listener metaListener = check new (8767);
+
+@mcp:ServiceConfig {
+    info: {name: "meta-test-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:Service /mcp on metaListener {
+
+    # Greets the caller, echoing the request's trace id when client metadata is supplied.
+    #
+    # + name - The name to greet
+    # + meta - Optional request metadata injected by the framework
+    # + return - A greeting message that reflects whether metadata was received
+    isolated remote function greetWithMeta(string name, mcp:Meta? meta) returns string {
+        if meta is mcp:Meta {
+            anydata traceId = meta["traceId"];
+            return string `Hello, ${name}! trace=${traceId.toString()}`;
+        }
+        return string `Hello, ${name}! no-meta`;
+    }
+}
+
+final mcp:StreamableHttpClient metaClient = check new ("http://localhost:8767/mcp");
+final mcp:Implementation metaClientInfo = {name: "meta-test-client", version: "1.0.0"};
+
+@test:Config
+function testMetaToolSchemaExcludesMetaParam() returns error? {
+    check metaClient->initialize(metaClientInfo);
+    mcp:ListToolsResult result = check metaClient->listTools();
+
+    test:assertEquals(result.tools.length(), 1);
+    test:assertEquals(result.tools[0].name, "greetWithMeta");
+
+    var inputSchema = result.tools[0].inputSchema;
+    map<record {}> properties = check inputSchema.properties.ensureType();
+    test:assertTrue(properties.hasKey("name"),
+        msg = "Schema must include the 'name' data parameter");
+    test:assertFalse(properties.hasKey("meta"),
+        msg = "The injected mcp:Meta parameter must not appear in the tool input schema");
+}
+
+@test:Config {dependsOn: [testMetaToolSchemaExcludesMetaParam]}
+function testMetaReceivedOnServer() returns error? {
+    mcp:CallToolResult result = check metaClient->callTool({
+        name: "greetWithMeta",
+        arguments: {"name": "World"},
+        _meta: {"traceId": "trace-xyz"}
+    });
+
+    // The server-side tool reads the injected client _meta via the mcp:Meta parameter
+    // and reflects it in the result text.
+    mcp:TextContent textContent = check result.content[0].ensureType();
+    test:assertEquals(textContent.text, "Hello, World! trace=trace-xyz",
+        msg = "Server must access the client-supplied _meta via the mcp:Meta parameter");
+
+    // The request _meta must not be auto-echoed onto the result (not mandated by the MCP spec).
+    test:assertTrue(result._meta is (),
+        msg = "Request _meta must not be echoed back onto the response");
+}
+
+@test:Config {dependsOn: [testMetaToolSchemaExcludesMetaParam]}
+function testMetaIsNilWhenClientOmitsIt() returns error? {
+    mcp:CallToolResult result = check metaClient->callTool({
+        name: "greetWithMeta",
+        arguments: {"name": "World"}
+    });
+
+    mcp:TextContent textContent = check result.content[0].ensureType();
+    test:assertEquals(textContent.text, "Hello, World! no-meta",
+        msg = "Tool must observe a nil mcp:Meta when the client sends no _meta");
+}

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Ballerina"]
 keywords = ["mcp"]
 repository = "https://github.com/ballerina-platform/module-ballerina-mcp"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib."
 artifactId = "mcp-native"
-version = "1.0.2"
-path = "../native/build/libs/mcp-native-1.0.2.jar"
+version = "1.0.3"
+path = "../native/build/libs/mcp-native-1.0.3-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "mcp-compiler-plugin"
 class = "io.ballerina.stdlib.mcp.plugin.McpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mcp-compiler-plugin-1.0.2.jar"
+path = "../compiler-plugin/build/libs/mcp-compiler-plugin-1.0.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -60,14 +60,17 @@ public type ProgressToken string|int;
 # An opaque token used to represent a cursor for pagination.
 public type Cursor string;
 
+# Optional metadata for requests
+public type Meta record {
+    # If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress).
+    # The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
+    ProgressToken progressToken?;
+};
+
 # Parameters for the request
 public type RequestParams record {
-    # Optional parameters for the request
-    record {
-        # If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress).
-        # The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-        ProgressToken progressToken?;
-    } _meta?;
+    # Optional metadata for the request
+    Meta _meta?;
 };
 
 # Represents a generic request in the protocol

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -315,6 +315,7 @@ public type ListToolsResult record {
 
 # The server's response to a tool call.
 public type CallToolResult record {
+    *Result;
     # The content of the tool call result
     (TextContent|ImageContent|AudioContent|EmbeddedResource)[] content;
     # Whether the tool call ended in an error.

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.mcp.plugin.RemoteFunctionAnalysisTask.EMPTY_STRING;
+import static io.ballerina.stdlib.mcp.plugin.Utils.isMetaParameter;
 import static io.ballerina.stdlib.mcp.plugin.Utils.isSessionType;
 
 /**
@@ -61,7 +62,9 @@ public class SchemaUtils {
         TypeMapper typeMapper = new TypeMapperImpl(context);
         for (ParameterSymbol parameterSymbol : parameterSymbolList) {
             try {
-                if (isSessionType(parameterSymbol.typeDescriptor())) {
+                // Skip Session and Meta parameters - they are not part of the tool schema
+                if (isSessionType(parameterSymbol.typeDescriptor()) ||
+                    isMetaParameter(parameterSymbol.typeDescriptor())) {
                     continue;
                 }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -33,7 +33,9 @@ public enum CompilationDiagnostic {
     UNABLE_TO_GENERATE_SCHEMA_FOR_FUNCTION(DiagnosticMessage.ERROR_101, DiagnosticCode.MCP_101, ERROR),
     INVALID_PARAMETER_TYPE(DiagnosticMessage.ERROR_102, DiagnosticCode.MCP_102, ERROR),
     SESSION_PARAM_MUST_BE_FIRST(DiagnosticMessage.ERROR_103, DiagnosticCode.MCP_103, ERROR),
-    SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR);
+    SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
+    META_PARAM_MUST_BE_LAST(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
+    META_PARAM_MUST_BE_OPTIONAL(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
@@ -25,5 +25,7 @@ public enum DiagnosticCode {
     MCP_101,
     MCP_102,
     MCP_103,
-    MCP_104
+    MCP_104,
+    MCP_105,
+    MCP_106
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
@@ -25,9 +25,12 @@ public enum DiagnosticMessage {
     ERROR_101("Failed to generate the parameter schema definition for the function ''{0}''." +
             " Specify the parameter schema manually using the `@mcp:McpTool` annotation's parameter field."),
     ERROR_102("Parameter ''{1}'' in function ''{0}'' must be of type 'anydata'. " +
-            "Only the first parameter can be of type 'mcp:Session'."),
+            "Only the first parameter can be of type 'mcp:Session' and only the last parameter can be of type " +
+            "'mcp:Meta'."),
     ERROR_103("Session parameter ''{1}'' in function ''{0}'' must be the first parameter."),
-    ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'.");
+    ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'."),
+    ERROR_105("Meta parameter ''{1}'' in function ''{0}'' must be the last parameter."),
+    ERROR_106("Meta parameter ''{1}'' in function ''{0}'' must be optional (e.g., 'mcp:Meta?').");
 
     private final String message;
 

--- a/examples/clients/mcp-crypto-client/Ballerina.toml
+++ b/examples/clients/mcp-crypto-client/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 repository = "local"

--- a/examples/clients/mcp-crypto-client/Ballerina.toml
+++ b/examples/clients/mcp-crypto-client/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 repository = "local"

--- a/examples/clients/mcp-crypto-client/Dependencies.toml
+++ b/examples/clients/mcp-crypto-client/Dependencies.toml
@@ -219,10 +219,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "uuid"}
 ]
@@ -238,6 +237,7 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mcp"},
+	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"}
 ]
 modules = [
@@ -298,7 +298,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -320,6 +320,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "uuid", moduleName = "uuid"}
 ]
 
 [[package]]

--- a/examples/clients/mcp-crypto-client/Dependencies.toml
+++ b/examples/clients/mcp-crypto-client/Dependencies.toml
@@ -219,7 +219,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/examples/clients/mcp-shopping-client/Ballerina.toml
+++ b/examples/clients/mcp-shopping-client/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 repository = "local"

--- a/examples/clients/mcp-shopping-client/Ballerina.toml
+++ b/examples/clients/mcp-shopping-client/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 repository = "local"

--- a/examples/clients/mcp-shopping-client/Dependencies.toml
+++ b/examples/clients/mcp-shopping-client/Dependencies.toml
@@ -219,10 +219,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "uuid"}
 ]
@@ -298,7 +297,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -306,7 +305,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/examples/clients/mcp-shopping-client/Dependencies.toml
+++ b/examples/clients/mcp-shopping-client/Dependencies.toml
@@ -219,7 +219,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/examples/clients/mcp-weather-client/Ballerina.toml
+++ b/examples/clients/mcp-weather-client/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 repository = "local"

--- a/examples/clients/mcp-weather-client/Ballerina.toml
+++ b/examples/clients/mcp-weather-client/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 repository = "local"

--- a/examples/clients/mcp-weather-client/Dependencies.toml
+++ b/examples/clients/mcp-weather-client/Dependencies.toml
@@ -219,10 +219,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "uuid"}
 ]
@@ -238,6 +237,7 @@ dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mcp"},
+	{org = "ballerina", name = "uuid"},
 	{org = "ballerinai", name = "observe"}
 ]
 modules = [
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.6.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -306,7 +306,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -320,6 +320,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.int"},
 	{org = "ballerina", name = "time"}
+]
+modules = [
+	{org = "ballerina", packageName = "uuid", moduleName = "uuid"}
 ]
 
 [[package]]

--- a/examples/clients/mcp-weather-client/Dependencies.toml
+++ b/examples/clients/mcp-weather-client/Dependencies.toml
@@ -219,7 +219,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/examples/clients/mcp-weather-client/main.bal
+++ b/examples/clients/mcp-weather-client/main.bal
@@ -73,6 +73,7 @@ function demonstrateCurrentWeather() returns mcp:ClientError? {
             arguments: {
                 "city": city
             },
+            // Attach request metadata; the server tool reads it via its mcp:Meta parameter (see server logs)
             _meta: {
                 "requestId": requestId
             }
@@ -81,13 +82,6 @@ function demonstrateCurrentWeather() returns mcp:ClientError? {
         io:println(string `Current Weather for ${city}:`);
         io:println(result.toString());
 
-        if result._meta is record {} {
-            io:println("\nResponse Metadata:");
-            record {} meta = <record {}>result._meta;
-            foreach var [key, value] in meta.entries() {
-                io:println(string `  ${key}: ${value.toString()}`);
-            }
-        }
         io:println("---");
     }
 }
@@ -111,6 +105,7 @@ function demonstrateWeatherForecast() returns mcp:ClientError? {
                 "location": testCase.location,
                 "days": testCase.days
             },
+            // Attach request metadata; the server tool reads it via its mcp:Meta parameter (see server logs)
             _meta: {
                 "requestId": requestId,
                 "forecastDays": testCase.days
@@ -120,13 +115,6 @@ function demonstrateWeatherForecast() returns mcp:ClientError? {
         io:println(string `${testCase.days}-Day Forecast for ${testCase.location}:`);
         io:println(result.toString());
 
-        if result._meta is record {} {
-            io:println("\nResponse Metadata:");
-            record {} meta = <record {}>result._meta;
-            foreach var [key, value] in meta.entries() {
-                io:println(string `  ${key}: ${value.toString()}`);
-            }
-        }
         io:println("---");
     }
 }

--- a/examples/servers/mcp-crypto-server/Ballerina.toml
+++ b/examples/servers/mcp-crypto-server/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 repository = "local"

--- a/examples/servers/mcp-crypto-server/Ballerina.toml
+++ b/examples/servers/mcp-crypto-server/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 repository = "local"

--- a/examples/servers/mcp-crypto-server/Dependencies.toml
+++ b/examples/servers/mcp-crypto-server/Dependencies.toml
@@ -222,10 +222,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "uuid"}
 ]
@@ -242,6 +241,7 @@ dependencies = [
 	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "mcp"},
+	{org = "ballerina", name = "time"},
 	{org = "ballerinai", name = "observe"}
 ]
 modules = [
@@ -302,15 +302,18 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "time", moduleName = "time"}
 ]
 
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/examples/servers/mcp-crypto-server/Dependencies.toml
+++ b/examples/servers/mcp-crypto-server/Dependencies.toml
@@ -222,7 +222,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/examples/servers/mcp-shopping-server/Ballerina.toml
+++ b/examples/servers/mcp-shopping-server/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 repository = "local"

--- a/examples/servers/mcp-shopping-server/Ballerina.toml
+++ b/examples/servers/mcp-shopping-server/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 repository = "local"

--- a/examples/servers/mcp-shopping-server/Dependencies.toml
+++ b/examples/servers/mcp-shopping-server/Dependencies.toml
@@ -216,10 +216,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "uuid"}
 ]
@@ -295,7 +294,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -306,7 +305,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/examples/servers/mcp-shopping-server/Dependencies.toml
+++ b/examples/servers/mcp-shopping-server/Dependencies.toml
@@ -216,7 +216,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/examples/servers/mcp-weather-server/Ballerina.toml
+++ b/examples/servers/mcp-weather-server/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 repository = "local"

--- a/examples/servers/mcp-weather-server/Ballerina.toml
+++ b/examples/servers/mcp-weather-server/Ballerina.toml
@@ -10,5 +10,5 @@ observabilityIncluded = true
 [[dependency]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 repository = "local"

--- a/examples/servers/mcp-weather-server/Dependencies.toml
+++ b/examples/servers/mcp-weather-server/Dependencies.toml
@@ -216,10 +216,9 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "uuid"}
 ]
@@ -269,7 +268,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.6.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -298,7 +297,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.10.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -308,7 +307,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -319,7 +318,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/examples/servers/mcp-weather-server/Dependencies.toml
+++ b/examples/servers/mcp-weather-server/Dependencies.toml
@@ -216,7 +216,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/examples/servers/mcp-weather-server/main.bal
+++ b/examples/servers/mcp-weather-server/main.bal
@@ -36,7 +36,12 @@ service mcp:Service /mcp on mcpListener {
             - location (string, required): City name or coordinates (e.g., "London", "40.7128,-74.0060")
             `
     }
-    remote function getCurrentWeather(string city) returns Weather|error {
+    remote function getCurrentWeather(string city, mcp:Meta? meta) returns Weather|error {
+        // Log received metadata if present
+        if meta is mcp:Meta {
+            log:printInfo(string `Received _meta from client: ${meta.toJsonString()}`);
+        }
+
         log:printInfo(string `Getting current weather for: ${city}`);
 
         // Generate random weather data
@@ -67,8 +72,14 @@ service mcp:Service /mcp on mcpListener {
     #
     # + location - City name or coordinates (e.g., "London", "40.7128,-74.0060")
     # + days - Number of days to forecast (1-7)
+    # + meta - Optional metadata for the request
     # + return - Weather forecast for the specified location and days
-    remote function getWeatherForecast(string location, int days) returns WeatherForecast|error {
+    remote function getWeatherForecast(string location, int days, mcp:Meta? meta) returns WeatherForecast|error {
+        // Log received metadata if present
+        if meta is mcp:Meta {
+            log:printInfo(string `Received _meta from client: ${meta.toJsonString()}`);
+        }
+
         log:printInfo(string `Getting ${days}-day weather forecast for: ${location}`);
 
         // Generate forecast items with random data

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -156,7 +156,7 @@ public final class McpServiceMethodHelper {
         Object[] args = (Object[]) argsOrError;
         Object result = env.getRuntime().callMethod(mcpService, toolName.getValue(), null, args);
 
-        return createCallToolResult(typed, result, meta);
+        return createCallToolResult(typed, result);
     }
 
     /**
@@ -276,7 +276,7 @@ public final class McpServiceMethodHelper {
         return false;
     }
 
-    private static Object createCallToolResult(BTypedesc typed, Object result, Object meta) {
+    private static Object createCallToolResult(BTypedesc typed, Object result) {
         RecordType resultRecordType = (RecordType) typed.getDescribingType();
         BMap<BString, Object> callToolResult = ValueCreator.createRecordValue(resultRecordType);
 
@@ -298,12 +298,6 @@ public final class McpServiceMethodHelper {
         contentArray.append(textContent);
 
         callToolResult.put(fromString(CONTENT_FIELD_NAME), contentArray);
-
-        // Attach modified metadata to response if present
-        if (meta != null) {
-            callToolResult.put(fromString(META_FIELD_NAME), meta);
-        }
-
         return callToolResult;
     }
 }


### PR DESCRIPTION
## Purpose
$title,

Fixes: https://github.com/wso2/product-ballerina-integrator/issues/1881

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Implemented end-to-end support for MCP `mcp:Meta` so agents can pass request metadata into tool invocations and allow servers to read it and return appropriate response metadata.

- Added a public `Meta` type and updated MCP request/result types to carry optional metadata (`_meta`), including support for progress tokens.
- Enhanced compiler plugin validation for `mcp:Meta` parameters: detect `mcp:Meta`/`mcp:Meta?`, enforce “only once” and “must be last and optional” rules, emit new diagnostics, and exclude `Meta` from generated tool input schemas.
- Updated the native MCP runtime to inject client `_meta` into tool arguments and to handle optional meta correctly.
- Updated examples (weather, crypto) to demonstrate sending `_meta` from clients and consuming/returning it on servers, including removal of obsolete response `_meta` display behavior in the weather example.
- Added test coverage for both stateless and advanced service paths, verifying injected request `_meta`, nil/omitted meta handling, and server-originated response `_meta` (including trace propagation behavior).
- Refreshed related dependency/version pins across the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->