### PR TITLE
Support for MCP protocol 2025-11-25

### DIFF
--- a/ballerina/constants.bal
+++ b/ballerina/constants.bal
@@ -16,6 +16,7 @@
 
 // Transport related constants (headers)
 const SESSION_ID_HEADER = "mcp-session-id";
+const PROTOCOL_VERSION_HEADER = "mcp-protocol-version";
 const ACCEPT_HEADER = "accept";
 const CONTENT_TYPE_HEADER = "content-type";
 const CONTENT_TYPE_JSON = "application/json";

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -30,6 +30,11 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
 
         isolated resource function delete .(http:Headers headers) returns http:BadRequest|http:Ok|Error {
             http:authenticateResource(self, "delete", []);
+            http:BadRequest? protocolVersionError =
+                    validateProtocolVersionHeader(getProtocolVersionFromHeaders(headers));
+            if protocolVersionError !is () {
+                return protocolVersionError;
+            }
             ServiceConfiguration config = check self.getCachedServiceConfiguration();
             SessionMode sessionMode = config.sessionMode;
 
@@ -72,6 +77,17 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             http:NotAcceptable|http:UnsupportedMediaType? headerValidationError = validateRequiredHeaders(headers);
             if headerValidationError !is () {
                 return headerValidationError;
+            }
+
+            // The MCP-Protocol-Version header is required on all requests after initialization. The
+            // initialize request itself establishes the version, so it is exempt from this validation.
+            boolean isInitializeRequest = request is JsonRpcRequest && request.method == REQUEST_INITIALIZE;
+            if !isInitializeRequest {
+                http:BadRequest? protocolVersionError =
+                        validateProtocolVersionHeader(getProtocolVersionFromHeaders(headers));
+                if protocolVersionError !is () {
+                    return protocolVersionError;
+                }
             }
 
             if request is JsonRpcRequest {
@@ -149,7 +165,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             SessionMode effectiveSessionMode = determineEffectiveSessionMode(serviceConfig, headers, REQUEST_INITIALIZE);
 
             string requestedVersion = initRequest.params.protocolVersion;
-            string protocolVersion = self.selectProtocolVersion(requestedVersion);
+            string protocolVersion = selectProtocolVersion(requestedVersion);
 
             InitializeResult initResult = {
                 protocolVersion: protocolVersion,
@@ -306,15 +322,6 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 headers: sessionId is string ? {[SESSION_ID_HEADER]: sessionId} : (),
                 body: responseBody
             };
-        }
-
-        private isolated function selectProtocolVersion(string requestedVersion) returns string {
-            foreach string supportedVersion in SUPPORTED_PROTOCOL_VERSIONS {
-                if supportedVersion == requestedVersion {
-                    return requestedVersion;
-                }
-            }
-            return LATEST_PROTOCOL_VERSION;
         }
 
         private isolated function executeOnListTools() returns ListToolsResult|Error {

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -136,8 +136,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
 
         private isolated function handleInitializeRequest(JsonRpcRequest jsonRpcRequest, http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
-            JsonRpcRequest {jsonrpc: _, id, ...request} = jsonRpcRequest;
-            InitializeRequest|error initRequest = request.cloneWithType();
+            RequestId? id = jsonRpcRequest.id;
+            InitializeRequest|error initRequest = jsonRpcRequest.cloneWithType();
             if initRequest is error {
                 return <http:BadRequest>{
                     body: createJsonRpcError(INVALID_REQUEST,
@@ -272,6 +272,14 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 return <http:BadRequest>{
                     body: createJsonRpcError(INVALID_PARAMS,
                             string `Invalid parameters: ${params.message()}`, request.id)
+                };
+            }
+
+            // Task-augmented tool calls are not yet supported.
+            if params.task !is () {
+                return <http:BadRequest>{
+                    body: createJsonRpcError(INVALID_REQUEST,
+                            "Task-augmented tool calls are not supported", request.id)
                 };
             }
 

--- a/ballerina/service_utils.bal
+++ b/ballerina/service_utils.bal
@@ -117,3 +117,49 @@ isolated function validateRequiredHeaders(http:Headers headers) returns http:Not
 
     return;
 }
+
+# Selects the protocol version to negotiate based on the client's requested version.
+# Echoes the requested version if supported; otherwise falls back to the latest supported version,
+# as required by the MCP version-negotiation lifecycle.
+#
+# + requestedVersion - The protocol version requested by the client
+# + return - The negotiated protocol version
+isolated function selectProtocolVersion(string requestedVersion) returns string {
+    foreach string supportedVersion in SUPPORTED_PROTOCOL_VERSIONS {
+        if supportedVersion == requestedVersion {
+            return requestedVersion;
+        }
+    }
+    return LATEST_PROTOCOL_VERSION;
+}
+
+# Extracts the `MCP-Protocol-Version` header value from the request headers, if present.
+#
+# + headers - HTTP headers to inspect
+# + return - The protocol version header value, or nil if absent
+isolated function getProtocolVersionFromHeaders(http:Headers headers) returns string? {
+    string|http:HeaderNotFoundError versionHeader = headers.getHeader(PROTOCOL_VERSION_HEADER);
+    return versionHeader is string ? versionHeader : ();
+}
+
+# Validates the `MCP-Protocol-Version` header sent on requests after initialization.
+# Per the Streamable HTTP transport spec: an absent header is tolerated (the server assumes
+# `2025-03-26` for backward compatibility), while a present but unsupported value must be rejected
+# with HTTP 400 Bad Request.
+#
+# + protocolVersion - The protocol version header value, or nil if absent
+# + return - A `400 Bad Request` response if the header is present and unsupported, otherwise nil
+isolated function validateProtocolVersionHeader(string? protocolVersion) returns http:BadRequest? {
+    if protocolVersion is () {
+        return;
+    }
+    foreach string supportedVersion in SUPPORTED_PROTOCOL_VERSIONS {
+        if supportedVersion == protocolVersion {
+            return;
+        }
+    }
+    return <http:BadRequest>{
+        body: createJsonRpcError(INVALID_REQUEST,
+                string `Unsupported MCP-Protocol-Version header: ${protocolVersion}`)
+    };
+}

--- a/ballerina/streamable_http.bal
+++ b/ballerina/streamable_http.bal
@@ -29,6 +29,8 @@ isolated class StreamableHttpClientTransport {
     private final string serverUrl;
     private final http:Client httpClient;
     private string? sessionId;
+    # Protocol version negotiated during initialization, sent on all subsequent requests.
+    private string? protocolVersion = ();
 
     # Initializes the HTTP client transport with the provided server URL.
     #
@@ -150,6 +152,7 @@ isolated class StreamableHttpClientTransport {
                 }
 
                 self.sessionId = ();
+                self.protocolVersion = ();
                 return;
             } on fail error e {
                 return error SessionOperationError(
@@ -168,13 +171,31 @@ isolated class StreamableHttpClientTransport {
         }
     }
 
+    # Records the protocol version negotiated during initialization. Once set, it is included as the
+    # `MCP-Protocol-Version` header on all subsequent requests, as required by the Streamable HTTP transport.
+    #
+    # + protocolVersion - The negotiated protocol version.
+    isolated function setProtocolVersion(string protocolVersion) {
+        lock {
+            self.protocolVersion = protocolVersion;
+        }
+    }
+
     # Prepares common HTTP headers for requests, including the session ID if present.
     #
     # + return - Map of common headers to include in each request.
     private isolated function prepareRequestHeaders() returns map<string> {
         lock {
+            map<string> headers = {};
             string? currentSessionId = self.sessionId;
-            return currentSessionId is string ? {[SESSION_ID_HEADER]: currentSessionId} : {};
+            if currentSessionId is string {
+                headers[SESSION_ID_HEADER] = currentSessionId;
+            }
+            string? currentProtocolVersion = self.protocolVersion;
+            if currentProtocolVersion is string {
+                headers[PROTOCOL_VERSION_HEADER] = currentProtocolVersion;
+            }
+            return headers.clone();
         }
     }
 

--- a/ballerina/streamable_http_client.bal
+++ b/ballerina/streamable_http_client.bal
@@ -83,6 +83,9 @@ public distinct isolated client class StreamableHttpClient {
         lock {
             self.serverCapabilities = response.capabilities.cloneReadOnly();
             self.serverInfo = response.serverInfo.cloneReadOnly();
+            // Record the negotiated version so it is sent as the MCP-Protocol-Version header
+            // on all subsequent requests (including the initialized notification below).
+            self.transport.setProtocolVersion(protocolVersion);
         }
 
         check self.sendNotificationMessage(<InitializedNotification>{});

--- a/ballerina/streamable_http_client.bal
+++ b/ballerina/streamable_http_client.bal
@@ -52,7 +52,8 @@ public distinct isolated client class StreamableHttpClient {
         }
 
         // Prepare and send the initialization request.
-        InitializeRequest initRequest = {
+        Request initRequest = {
+            method: REQUEST_INITIALIZE,
             params: {
                 protocolVersion: LATEST_PROTOCOL_VERSION,
                 capabilities: capabilities,
@@ -120,6 +121,15 @@ public distinct isolated client class StreamableHttpClient {
     # + return - Result of the tool execution or a ClientError.
     isolated remote function callTool(CallToolParams params, map<string|string[]> headers = {})
             returns CallToolResult|ClientError {
+        // Reject task-augmented calls when the server hasn't advertised task support.
+        if params.task !is () {
+            lock {
+                if self.serverCapabilities?.tasks?.requests?.tools?.call is () {
+                    return error ToolCallError("Server does not support task-augmented tool calls");
+                }
+            }
+        }
+
         CallToolRequest toolCallRequest = {
             params: params
         };

--- a/ballerina/tests/protocol_version_client_test.bal
+++ b/ballerina/tests/protocol_version_client_test.bal
@@ -1,0 +1,143 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+const string MOCK_SERVER_URL = "http://localhost:3202/mcp";
+
+// Protocol version the mock server echoes back during initialization (controllable per test).
+isolated string mockNegotiatedVersion = "2025-06-18";
+// The MCP-Protocol-Version header value captured on the last non-initialize request.
+isolated string? mockCapturedVersionHeader = ();
+// Whether the initialize request carried an MCP-Protocol-Version header (it must not).
+isolated boolean mockInitHadVersionHeader = false;
+
+isolated function setMockNegotiatedVersion(string version) {
+    lock {
+        mockNegotiatedVersion = version;
+    }
+}
+
+isolated function resetMockCapturedState() {
+    lock {
+        mockCapturedVersionHeader = ();
+    }
+    lock {
+        mockInitHadVersionHeader = false;
+    }
+}
+
+isolated function getMockCapturedVersionHeader() returns string? {
+    lock {
+        return mockCapturedVersionHeader;
+    }
+}
+
+isolated function getMockInitHadVersionHeader() returns boolean {
+    lock {
+        return mockInitHadVersionHeader;
+    }
+}
+
+// A minimal MCP-like HTTP server used to drive client-side protocol version negotiation behavior.
+isolated service /mcp on new http:Listener(3202) {
+    isolated resource function post .(@http:Payload json payload, http:Headers headers)
+            returns http:Ok|http:Accepted|error {
+        string method = check payload.method.ensureType();
+        string|http:HeaderNotFoundError versionHeader = headers.getHeader(PROTOCOL_VERSION_HEADER);
+
+        if method == REQUEST_INITIALIZE {
+            lock {
+                mockInitHadVersionHeader = versionHeader is string;
+            }
+            string negotiatedVersion;
+            lock {
+                negotiatedVersion = mockNegotiatedVersion;
+            }
+            return <http:Ok>{
+                body: {
+                    jsonrpc: JSONRPC_VERSION,
+                    id: check payload.id,
+                    result: {
+                        protocolVersion: negotiatedVersion,
+                        capabilities: {tools: {}},
+                        serverInfo: {name: "mock-server", version: "1.0.0"}
+                    }
+                }
+            };
+        }
+
+        lock {
+            mockCapturedVersionHeader = versionHeader is string ? versionHeader : ();
+        }
+
+        if method == NOTIFICATION_INITIALIZED {
+            return http:ACCEPTED;
+        }
+
+        // tools/list and any other request.
+        return <http:Ok>{
+            body: {
+                jsonrpc: JSONRPC_VERSION,
+                id: check payload.id,
+                result: {tools: []}
+            }
+        };
+    }
+}
+
+// The client must omit the header on initialize but send the negotiated version on all later requests.
+@test:Config {}
+function testClientSendsNegotiatedProtocolVersionHeader() returns error? {
+    setMockNegotiatedVersion("2025-06-18");
+    resetMockCapturedState();
+
+    StreamableHttpClient 'client = check new (MOCK_SERVER_URL);
+    check 'client->initialize();
+
+    test:assertFalse(getMockInitHadVersionHeader(),
+            "initialize request must not carry an MCP-Protocol-Version header");
+
+    ListToolsResult _ = check 'client->listTools();
+    test:assertEquals(getMockCapturedVersionHeader(), "2025-06-18",
+            "subsequent requests must carry the negotiated MCP-Protocol-Version header");
+}
+
+// The client must accept a server that downgrades to an older supported version and send that version.
+@test:Config {}
+function testClientSendsDowngradedProtocolVersionHeader() returns error? {
+    setMockNegotiatedVersion("2025-03-26");
+    resetMockCapturedState();
+
+    StreamableHttpClient 'client = check new (MOCK_SERVER_URL);
+    check 'client->initialize();
+
+    ListToolsResult _ = check 'client->listTools();
+    test:assertEquals(getMockCapturedVersionHeader(), "2025-03-26",
+            "client must send the downgraded negotiated version as the MCP-Protocol-Version header");
+}
+
+// The client must disconnect (error) if the server returns a version it does not support.
+@test:Config {}
+function testClientRejectsUnsupportedNegotiatedVersion() returns error? {
+    setMockNegotiatedVersion("1999-01-01");
+
+    StreamableHttpClient 'client = check new (MOCK_SERVER_URL);
+    ClientError? result = 'client->initialize();
+    test:assertTrue(result is ProtocolVersionError,
+            "client must reject an unsupported negotiated protocol version");
+}

--- a/ballerina/tests/protocol_version_server_test.bal
+++ b/ballerina/tests/protocol_version_server_test.bal
@@ -1,0 +1,119 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+listener Listener pvServerListener = check new (3201);
+
+@ServiceConfig {
+    info: {
+        name: "Protocol Version Test Server",
+        version: "1.0.0"
+    },
+    sessionMode: STATELESS
+}
+service Service /mcp on pvServerListener {
+    @Tool {
+        description: "Echoes the provided message back to the caller."
+    }
+    remote function echo(string message) returns string => message;
+}
+
+final http:Client pvServerClient = check new ("http://localhost:3201");
+
+isolated function sendToServer(json payload, map<string|string[]> extraHeaders = {}) returns http:Response|error {
+    map<string|string[]> headers = {
+        [ACCEPT_HEADER]: string `${CONTENT_TYPE_JSON}, ${CONTENT_TYPE_SSE}`,
+        [CONTENT_TYPE_HEADER]: CONTENT_TYPE_JSON
+    };
+    foreach var [key, value] in extraHeaders.entries() {
+        headers[key] = value;
+    }
+    return pvServerClient->post("/mcp", payload, headers);
+}
+
+isolated function initializePayload(string protocolVersion) returns json => {
+    jsonrpc: JSONRPC_VERSION,
+    id: 1,
+    method: REQUEST_INITIALIZE,
+    params: {
+        protocolVersion: protocolVersion,
+        capabilities: {},
+        clientInfo: {name: "test-client", version: "1.0.0"}
+    }
+};
+
+final json LIST_TOOLS_PAYLOAD = {
+    jsonrpc: JSONRPC_VERSION,
+    id: 2,
+    method: REQUEST_LIST_TOOLS,
+    params: {}
+};
+
+// Negotiation: server echoes a supported requested version.
+@test:Config {}
+function testServerEchoesSupportedNegotiatedVersion() returns error? {
+    http:Response response = check sendToServer(initializePayload("2025-06-18"));
+    test:assertEquals(response.statusCode, 200);
+    json body = check response.getJsonPayload();
+    json result = check body.result;
+    string negotiated = check result.protocolVersion.ensureType();
+    test:assertEquals(negotiated, "2025-06-18");
+}
+
+// Negotiation: server falls back to its latest version for an unsupported request.
+@test:Config {}
+function testServerFallsBackToLatestForUnsupportedVersion() returns error? {
+    http:Response response = check sendToServer(initializePayload("1.0.0"));
+    test:assertEquals(response.statusCode, 200);
+    json body = check response.getJsonPayload();
+    json result = check body.result;
+    string negotiated = check result.protocolVersion.ensureType();
+    test:assertEquals(negotiated, LATEST_PROTOCOL_VERSION);
+}
+
+// Transport: initialize is exempt from header validation even if an invalid header is present.
+@test:Config {}
+function testServerExemptsInitializeFromProtocolVersionHeader() returns error? {
+    http:Response response = check sendToServer(initializePayload("2025-11-25"),
+            {[PROTOCOL_VERSION_HEADER]: "1999-01-01"});
+    test:assertEquals(response.statusCode, 200, "initialize must not be subject to MCP-Protocol-Version validation");
+}
+
+// Transport: a supported MCP-Protocol-Version header is accepted on subsequent requests.
+@test:Config {}
+function testServerAcceptsSupportedProtocolVersionHeader() returns error? {
+    http:Response response = check sendToServer(LIST_TOOLS_PAYLOAD,
+            {[PROTOCOL_VERSION_HEADER]: "2025-06-18"});
+    test:assertEquals(response.statusCode, 200);
+}
+
+// Transport: a missing MCP-Protocol-Version header is tolerated for backward compatibility.
+@test:Config {}
+function testServerAllowsMissingProtocolVersionHeader() returns error? {
+    http:Response response = check sendToServer(LIST_TOOLS_PAYLOAD);
+    test:assertEquals(response.statusCode, 200);
+}
+
+// Transport: an unsupported MCP-Protocol-Version header must be rejected with 400.
+@test:Config {}
+function testServerRejectsUnsupportedProtocolVersionHeader() returns error? {
+    http:Response response = check sendToServer(LIST_TOOLS_PAYLOAD,
+            {[PROTOCOL_VERSION_HEADER]: "1999-01-01"});
+    test:assertEquals(response.statusCode, 400,
+            "unsupported MCP-Protocol-Version header must be rejected with 400 Bad Request");
+}

--- a/ballerina/tests/protocol_version_test.bal
+++ b/ballerina/tests/protocol_version_test.bal
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/test;
+
+// Version negotiation: the server must echo a requested version it supports.
+@test:Config {}
+function testSelectProtocolVersionEchoesSupportedVersions() {
+    foreach string supportedVersion in SUPPORTED_PROTOCOL_VERSIONS {
+        test:assertEquals(selectProtocolVersion(supportedVersion), supportedVersion,
+                string `Server should echo the supported requested version '${supportedVersion}'`);
+    }
+}
+
+// Version negotiation: for an unsupported request, the server must fall back to its latest version.
+@test:Config {}
+function testSelectProtocolVersionFallsBackToLatest() {
+    test:assertEquals(selectProtocolVersion("1.0.0"), LATEST_PROTOCOL_VERSION);
+    test:assertEquals(selectProtocolVersion("2099-01-01"), LATEST_PROTOCOL_VERSION);
+    test:assertEquals(selectProtocolVersion(""), LATEST_PROTOCOL_VERSION);
+}
+
+// Transport: an absent MCP-Protocol-Version header is tolerated (server assumes 2025-03-26).
+@test:Config {}
+function testValidateProtocolVersionHeaderAbsentIsAllowed() {
+    http:BadRequest? result = validateProtocolVersionHeader(());
+    test:assertTrue(result is (), "Absent MCP-Protocol-Version header must be tolerated");
+}
+
+// Transport: a present, supported MCP-Protocol-Version header is accepted.
+@test:Config {}
+function testValidateProtocolVersionHeaderSupportedIsAllowed() {
+    foreach string supportedVersion in SUPPORTED_PROTOCOL_VERSIONS {
+        http:BadRequest? result = validateProtocolVersionHeader(supportedVersion);
+        test:assertTrue(result is (),
+                string `Supported MCP-Protocol-Version header '${supportedVersion}' must be accepted`);
+    }
+}
+
+// Transport: a present, unsupported MCP-Protocol-Version header must be rejected with 400.
+@test:Config {}
+function testValidateProtocolVersionHeaderUnsupportedIsRejected() {
+    http:BadRequest? result = validateProtocolVersionHeader("1999-01-01");
+    test:assertTrue(result is http:BadRequest,
+            "Unsupported MCP-Protocol-Version header must be rejected with 400 Bad Request");
+}

--- a/ballerina/tests/stateless_client_initialization_test.bal
+++ b/ballerina/tests/stateless_client_initialization_test.bal
@@ -137,6 +137,30 @@ function testInitializationWithClientCapabilities() returns error? {
 }
 
 @test:Config {}
+function testInitializationWithExperimentalCapability() returns error? {
+    ClientCapabilities capabilities = {
+        experimental: {"customFeature": {}}
+    };
+    error? result = mcpClient->initialize(clientInfo, capabilities);
+
+    test:assertFalse(result is error);
+}
+
+@test:Config {}
+function testInitializationWithExtendedImplementationInfo() returns error? {
+    Implementation extendedClientInfo = {
+        name: TEST_CLIENT_NAME,
+        title: "Test MCP Client",
+        version: TEST_CLIENT_VERSION,
+        description: "A client used for integration testing",
+        websiteUrl: "https://example.com"
+    };
+    error? result = mcpClient->initialize(extendedClientInfo);
+
+    test:assertFalse(result is error);
+}
+
+@test:Config {}
 function testInitializationWithEmptyCapabilities() returns error? {
     ClientCapabilities capabilities = {};
     error? result = mcpClient->initialize(clientInfo, capabilities);

--- a/ballerina/tests/types_test.bal
+++ b/ballerina/tests/types_test.bal
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+// ---------------------------------------------------------------------------
+// Implementation — verifies new fields: title, description, websiteUrl, icons
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testImplementation() {
+    Implementation impl = {
+        name: "my-server",
+        title: "My Server",
+        version: "1.0.0",
+        description: "An MCP server",
+        websiteUrl: "https://example.com",
+        icons: [
+            {mimeType: "image/png", data: "icon16", size: 16},
+            {mimeType: "image/svg+xml", data: "<svg/>"}
+        ]
+    };
+    test:assertEquals(impl.title, "My Server");
+    test:assertEquals(impl.description, "An MCP server");
+    test:assertEquals(impl.websiteUrl, "https://example.com");
+    Icon[] icons = impl.icons ?: [];
+    test:assertEquals(icons.length(), 2);
+    test:assertEquals(icons[0].size, 16);
+}
+
+// ---------------------------------------------------------------------------
+// ClientCapabilities — verifies new fields: elicitation, tasks
+// Note: task types are defined for protocol compatibility but server-side
+// task execution is not yet supported.
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testClientCapabilities() {
+    ClientCapabilities capabilities = {
+        sampling: {context: {}, tools: {}},
+        elicitation: {form: {}, url: {}},
+        tasks: {
+            list: {},
+            cancel: {},
+            requests: {
+                sampling: {createMessage: {}},
+                elicitation: {create: {}}
+            }
+        }
+    };
+    test:assertTrue(capabilities.elicitation?.form != ());
+    test:assertTrue(capabilities.elicitation?.url != ());
+    test:assertTrue(capabilities.tasks?.list != ());
+    test:assertTrue(capabilities.tasks?.cancel != ());
+    test:assertTrue(capabilities.tasks?.requests?.sampling?.createMessage != ());
+    test:assertTrue(capabilities.tasks?.requests?.elicitation?.create != ());
+}
+
+// ---------------------------------------------------------------------------
+// ServerCapabilities — verifies new tasks field
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testServerCapabilities() {
+    ServerCapabilities capabilities = {
+        tools: {listChanged: true},
+        tasks: {
+            list: {},
+            cancel: {},
+            requests: {tools: {call: {}}}
+        }
+    };
+    test:assertEquals(capabilities.tools?.listChanged, true);
+    test:assertTrue(capabilities.tasks?.list != ());
+    test:assertTrue(capabilities.tasks?.requests?.tools?.call != ());
+}
+
+// ---------------------------------------------------------------------------
+// ResourceLink — verifies new type field and inherited Resource fields
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testResourceLink() {
+    ResourceLink link = {
+        name: "report",
+        uri: "file:///report.pdf",
+        'type: "resource_link",
+        mimeType: "application/pdf",
+        description: "Generated report",
+        size: 8192
+    };
+    test:assertEquals(link.'type, "resource_link");
+    test:assertEquals(link.mimeType, "application/pdf");
+    test:assertEquals(link.size, 8192);
+}
+
+// ---------------------------------------------------------------------------
+// ContentBlock union — verifies all five member types are assignable
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testContentBlockUnion() {
+    ContentBlock text = {'type: "text", text: "Hello"};
+    ContentBlock image = {'type: "image", data: "base64", mimeType: "image/png"};
+    ContentBlock audio = {'type: "audio", data: "base64", mimeType: "audio/mpeg"};
+    ContentBlock resLink = {'type: "resource_link", name: "f", uri: "file:///f.txt"};
+    ContentBlock embedded = {'type: "resource", 'resource: {uri: "file:///f.txt", text: "content"}};
+
+    test:assertTrue(text is TextContent);
+    test:assertTrue(image is ImageContent);
+    test:assertTrue(audio is AudioContent);
+    test:assertTrue(resLink is ResourceLink);
+    test:assertTrue(embedded is EmbeddedResource);
+}
+
+// ---------------------------------------------------------------------------
+// ToolDefinition — verifies new fields: title, icons, execution, outputSchema
+// Note: execution.taskSupport describes protocol capability; server-side task
+// execution is not yet supported.
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testToolDefinition() {
+    ToolDefinition tool = {
+        name: "calculate",
+        title: "Calculate",
+        description: "Performs a calculation",
+        inputSchema: {
+            'type: "object",
+            properties: {"x": {}, "y": {}},
+            required: ["x", "y"]
+        },
+        outputSchema: {
+            'type: "object",
+            properties: {"result": {}}
+        },
+        execution: {taskSupport: "optional"},
+        icons: [{mimeType: "image/png", data: "icon", size: 32}]
+    };
+    test:assertEquals(tool.title, "Calculate");
+    test:assertEquals(tool.outputSchema?.'type, "object");
+    test:assertEquals(tool.execution?.taskSupport, "optional");
+    test:assertEquals((tool.icons ?: [])[0].size, 32);
+}
+
+// ---------------------------------------------------------------------------
+// CallToolParams — verifies name and arguments fields
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testCallToolParams() {
+    CallToolParams withArgs = {
+        name: "tool_with_args",
+        arguments: {"input": "data"}
+    };
+    CallToolParams withoutArgs = {name: "sync_tool"};
+    test:assertEquals(withArgs.name, "tool_with_args");
+    test:assertEquals(withoutArgs.arguments, ());
+}
+
+// ---------------------------------------------------------------------------
+// CallToolResult — verifies structuredContent and ResourceLink in content
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testCallToolResult() {
+    CallToolResult result = {
+        content: [
+            {'type: "text", text: "Summary"},
+            {'type: "resource_link", name: "output", uri: "file:///out.json"}
+        ],
+        structuredContent: {"value": 42}
+    };
+    test:assertEquals(result.content.length(), 2);
+    test:assertTrue(result.content[1] is ResourceLink);
+    test:assertTrue(result.structuredContent != ());
+    test:assertEquals(result.isError, ());
+}
+
+// ---------------------------------------------------------------------------
+// JsonRpcResponseTypes — verifies ServerResult union membership
+// ---------------------------------------------------------------------------
+
+@test:Config {}
+function testJsonRpcResponseTypes() {
+    CallToolResult toolResult = {content: [{'type: "text", text: "done"}]};
+    JsonRpcResponse resultResponse = {jsonrpc: "2.0", id: 1, result: toolResult};
+    JsonRpcError errorResponse = {
+        jsonrpc: "2.0",
+        id: (),
+        'error: {code: INTERNAL_ERROR, message: "Internal error"}
+    };
+
+    JsonRpcMessage r1 = resultResponse;
+    JsonRpcMessage r2 = errorResponse;
+    test:assertTrue(r1 is JsonRpcResponse);
+    test:assertTrue(r2 is JsonRpcError);
+    test:assertEquals(errorResponse.'error.code, -32603);
+}

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,9 +19,11 @@ import ballerina/http;
 # Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.
 public type JsonRpcMessage JsonRpcRequest|JsonRpcNotification|JsonRpcError|JsonRpcResponse;
 
-public const LATEST_PROTOCOL_VERSION = "2025-03-26";
+public const LATEST_PROTOCOL_VERSION = "2025-11-25";
 public const SUPPORTED_PROTOCOL_VERSIONS = [
     LATEST_PROTOCOL_VERSION,
+    "2025-06-18",
+    "2025-03-26",
     "2024-11-05",
     "2024-10-07"
 ];
@@ -75,7 +77,7 @@ public type Request record {|
     # The method name for the request
     string method;
     # Optional parameters for the request
-    RequestParams params?;
+    map<anydata> params?;
 |};
 
 # Represents a notification.
@@ -161,7 +163,7 @@ public type JsonRpcError record {|
 
 # This request is sent from the client to the server when it first connects, asking it to begin initialization.
 type InitializeRequest record {|
-    *Request;
+    *JsonRpcRequest;
     # Method name for the request
     REQUEST_INITIALIZE method = REQUEST_INITIALIZE;
     # Parameters for the initialize request
@@ -205,24 +207,57 @@ public type InitializedNotification record {|
 # Capabilities a client may support. Known capabilities are defined here, in this schema,
 # but this is not a closed set: any client can define its own, additional capabilities.
 public type ClientCapabilities record {
+    # Experimental, non-standard capabilities that the client supports.
+    map<anydata> experimental?;
     # Present if the client supports listing roots.
     record {
         # Whether the client supports notifications for changes to the roots list.
         boolean listChanged?;
     } roots?;
-    # Present if the client supports sampling from an LLM. 
-    record {} sampling?;
+    # Present if the client supports sampling from an LLM.
+    record {
+        # Whether the client supports context inclusion via includeContext parameter.
+        # If not declared, servers SHOULD only use `includeContext: "none"` (or omit it).
+        map<anydata> context?;
+        # Whether the client supports tool use via tools and toolChoice parameters.
+        map<anydata> tools?;
+    } sampling?;
+    # Present if the client supports elicitation from the server.
+    record {
+        map<anydata> form?;
+        map<anydata> url?;
+    } elicitation?;
+    # Present if the client supports task-augmented requests.
+    record {
+        # Whether this client supports tasks/list.
+        map<anydata> list?;
+        # Whether this client supports tasks/cancel.
+        map<anydata> cancel?;
+        # Specifies which request types can be augmented with tasks.
+        record {
+            # Task support for sampling-related requests.
+            record {
+                # Whether the client supports task-augmented sampling/createMessage requests.
+                map<anydata> createMessage?;
+            } sampling?;
+            # Task support for elicitation-related requests.
+            record {
+                # Whether the client supports task-augmented elicitation/create requests.
+                map<anydata> create?;
+            } elicitation?;
+        } requests?;
+    } tasks?;
 };
 
 # Capabilities that a server may support. Known capabilities are defined here, in this schema,
 # but this is not a closed set: any server can define its own, additional capabilities.
 public type ServerCapabilities record {
     # Experimental, non-standard capabilities that the server supports.
-    record {|record {}...;|} experimental?;
+    map<anydata> experimental?;
     # Present if the server supports sending log messages to the client.
-    record {|record {}...;|} logging?;
+    map<anydata> logging?;
     # Present if the server supports argument autocompletion suggestions.
-    record {|record {}...;|} completions?;
+    map<anydata> completions?;
     # Present if the server offers any prompt templates.
     record {
         # Whether this server supports notifications for changes to the prompt list.
@@ -240,14 +275,59 @@ public type ServerCapabilities record {
         # Whether this server supports notifications for changes to the tool list.
         boolean listChanged?;
     } tools?;
+    # Present if the server supports task-augmented requests.
+    record {
+        # Whether this server supports tasks/list.
+        map<anydata> list?;
+        # Whether this server supports tasks/cancel.
+        map<anydata> cancel?;
+        # Specifies which request types can be augmented with tasks.
+        record {
+            # Task support for tool-related requests.
+            record {
+                # Whether the server supports task-augmented tools/call requests.
+                map<anydata> call?;
+            } tools?;
+        } requests?;
+    } tasks?;
+};
+
+# Base metadata with name (identifier) and title (display name) properties.
+public type BaseMetadata record {|
+    # Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+    string name;
+    # Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+    # even by those unfamiliar with domain-specific terminology.
+    string title?;
+|};
+
+# Represents a sized icon that can be displayed in a user interface.
+public type Icon record {
+    # The MIME type of the icon (e.g. image/png, image/jpeg, image/svg+xml, image/webp)
+    string mimeType;
+    # The URL or base64-encoded data of the icon
+    string data;
+    # The size of the icon (e.g. 16, 32, 64, 128, 256)
+    int size?;
+};
+
+# Optional set of sized icons that the client can display in a user interface.
+public type Icons record {
+    # Optional set of sized icons that the client can display in a user interface.
+    # Supported MIME types: image/png, image/jpeg, image/svg+xml, image/webp
+    Icon[] icons?;
 };
 
 # Describes the name and version of an MCP implementation.
 public type Implementation record {
-    # The name of the implementation
-    string name;
+    *BaseMetadata;
+    *Icons;
     # The version of the implementation
     string version;
+    # An optional human-readable description of what this implementation does.
+    string description?;
+    # An optional URL of the website for this implementation.
+    string websiteUrl?;
 };
 
 # Represents a paginated request with optional cursor-based pagination.
@@ -286,8 +366,31 @@ public type BlobResourceContents record {
     string blob;
 };
 
+# A known resource that the server is capable of reading.
+public type Resource record {
+    *BaseMetadata;
+    *Icons;
+    # The URI of this resource.
+    string uri;
+    # A description of what this resource represents.
+    string description?;
+    # The MIME type of this resource, if known.
+    string mimeType?;
+    # Optional annotations for the client.
+    Annotations annotations?;
+    # The size of the raw resource content, in bytes, if known.
+    int size?;
+};
+
 # The sender or recipient of messages and data in a conversation.
 public type Role "user"|"assistant";
+
+# A resource that the server is capable of reading, included in a prompt or tool call result.
+public type ResourceLink record {
+    *Resource;
+    # The type of content
+    "resource_link" 'type;
+};
 
 # The contents of a resource, embedded into a prompt or tool call result.
 public type EmbeddedResource record {
@@ -313,10 +416,16 @@ public type ListToolsResult record {
     ToolDefinition[] tools;
 };
 
+# A content block that can be text, image, audio, resource link, or embedded resource.
+public type ContentBlock TextContent|ImageContent|AudioContent|ResourceLink|EmbeddedResource;
+
 # The server's response to a tool call.
 public type CallToolResult record {
-    # The content of the tool call result
-    (TextContent|ImageContent|AudioContent|EmbeddedResource)[] content;
+    *Result;
+    # A list of content objects that represent the unstructured result of the tool call.
+    ContentBlock[] content;
+    # An optional JSON object that represents the structured result of the tool call.
+    map<anydata> structuredContent?;
     # Whether the tool call ended in an error.
     # If not set, this is assumed to be false (the call was successful).
     boolean isError?;
@@ -337,6 +446,12 @@ public type CallToolParams record {|
     string name;
     # Optional arguments to pass to the tool
     record {} arguments?;
+    # If present, this is a task-augmented request (MCP 2025-11-25 TaskAugmentedRequestParams).
+    # Currently disallowed — no server advertises `tasks.requests.tools.call` yet.
+    record {|
+        # Optional time-to-live in milliseconds for the task.
+        int ttl?;
+    |} task?;
 |};
 
 # Additional properties describing a Tool to clients.
@@ -365,32 +480,67 @@ public type ToolAnnotations record {
     boolean openWorldHint?;
 };
 
+# Indicates whether a tool supports task-augmented execution.
+public enum TaskSupport {
+    # Task-augmented execution is not allowed for this tool.
+    TASK_SUPPORT_FORBIDDEN = "forbidden",
+    # Task-augmented execution is allowed but not required for this tool.
+    TASK_SUPPORT_OPTIONAL = "optional",
+    # Task-augmented execution is required for this tool.
+    TASK_SUPPORT_REQUIRED = "required"
+}
+
+# Execution-related properties for a tool.
+public type ToolExecution record {|
+    # Indicates whether this tool supports task-augmented execution.
+    TaskSupport taskSupport = TASK_SUPPORT_FORBIDDEN;
+|};
+
 # Definition for a tool the client can call.
 public type ToolDefinition record {
-    # The name of the tool
-    string name;
-    # A human-readable description of the tool
-    # This can be used by clients to improve the LLM's understanding of available tools.
+    *BaseMetadata;
+    *Icons;
+    # A human-readable description of the tool.
     string description?;
     # A JSON Schema object defining the expected parameters for the tool.
     record {
+        # The JSON Schema version
+        string \$schema?;
+        # The type of the schema
         "object" 'type;
-        record {|record {}...;|} properties?;
+        # The properties of the schema
+        map<anydata> properties?;
+        # The required properties of the schema
         string[] required?;
     } inputSchema;
+    # Execution-related properties for this tool.
+    ToolExecution execution?;
+    # An optional JSON Schema object defining the structure of the tool's output.
+    record {
+        # The JSON Schema version
+        string \$schema?;
+        # The type of the schema
+        "object" 'type;
+        # The properties of the schema
+        map<anydata> properties?;
+        # The required properties of the schema
+        string[] required?;
+    } outputSchema?;
     # Optional additional tool information.
     ToolAnnotations annotations?;
 };
 
 # Optional annotations for the client. The client can use annotations to inform how objects are used or displayed
 public type Annotations record {|
-    # Describes who the intended customer of this object or data is.
+    # Describes who the intended audience of this object or data is.
     # This can include multiple entries to indicate content useful for multiple audiences (e.g., `["user", "assistant"]`).
     Role[] audience?;
     # Describes how important this data is for operating the server.
     # A value of 1 means "most important," and indicates that the data is effectively required,
     # while 0 means "least important," and indicates that the data is entirely optional.
     decimal priority?;
+    # The moment the resource was last modified, as an ISO 8601 formatted string.
+    string lastModified?;
 |};
 
 # Text provided to or from an LLM.

--- a/changelog.md
+++ b/changelog.md
@@ -2,3 +2,8 @@
 This file contains all the notable changes done to the Ballerina MCP package through the releases.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Partial support for MCP protocol version `2025-11-25`, with backward compatibility for `2025-06-18`, `2025-03-26`, and `2024-11-05`. Task-augmented requests introduced in `2025-11-25` are not yet supported.

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -23,12 +23,12 @@ import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RecordType;
-import io.ballerina.runtime.api.types.ReferenceType;
 import io.ballerina.runtime.api.types.RemoteMethodType;
 import io.ballerina.runtime.api.types.ServiceType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeTags;
 import io.ballerina.runtime.api.types.UnionType;
+import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
@@ -194,7 +194,7 @@ public final class McpServiceMethodHelper {
 
     private static BMap<BString, Object> createToolRecord(ArrayType toolsArrayType, RemoteMethodType remoteMethod,
                                                           BMap<?, ?> annotationValue) {
-        RecordType toolRecordType = (RecordType) ((ReferenceType) toolsArrayType.getElementType()).getReferredType();
+        RecordType toolRecordType = (RecordType) TypeUtils.getImpliedType(toolsArrayType.getElementType());
         BMap<BString, Object> tool = ValueCreator.createRecordValue(toolRecordType);
 
         tool.put(fromString(NAME_FIELD_NAME), fromString(remoteMethod.getName()));
@@ -253,7 +253,12 @@ public final class McpServiceMethodHelper {
         ArrayType contentArrayType = (ArrayType) resultRecordType.getFields().get(CONTENT_FIELD_NAME).getFieldType();
         BArray contentArray = ValueCreator.createArrayValue(contentArrayType);
 
-        UnionType contentUnionType = (UnionType) contentArrayType.getElementType();
+        Type contentElementType = TypeUtils.getImpliedType(contentArrayType.getElementType());
+        if (!(contentElementType instanceof UnionType contentUnionType)) {
+            return ModuleUtils.createError(
+                    "Expected content element type to be a union type, but found: "
+                            + contentElementType.getClass().getName());
+        }
         Optional<Type> textContentTypeOpt = contentUnionType.getMemberTypes().stream()
                 .filter(type -> TYPE_TEXT_CONTENT.equals(type.getName()))
                 .findFirst();
@@ -261,7 +266,7 @@ public final class McpServiceMethodHelper {
             return ModuleUtils
                     .createError("No member type named 'TextContent' found in content union type.");
         }
-        RecordType textContentRecordType = (RecordType) ((ReferenceType) textContentTypeOpt.get()).getReferredType();
+        RecordType textContentRecordType = (RecordType) TypeUtils.getImpliedType(textContentTypeOpt.get());
         BMap<BString, Object> textContent = ValueCreator.createRecordValue(textContentRecordType);
         textContent.put(fromString(TYPE_FIELD_NAME), fromString(TEXT_VALUE_NAME));
         textContent.put(fromString(TEXT_FIELD_NAME), fromString(result == null ? "" : result.toString()));


### PR DESCRIPTION
## Purpose

It resolves: https://github.com/wso2/product-integrator/issues/1434

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the specification
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates the Ballerina MCP toolkit to support MCP protocol **2025-11-25**, resolving initialization failures when connecting to MCP servers exposed via **WSO2 API Manager 4.6.0** caused by an earlier protocol/version mismatch. Backward compatibility is maintained by continuing to support **2025-06-18**, **2025-03-26**, and **2024-11-05**.

## Key Changes

### Protocol and capability support
- Updated MCP protocol version constants to make **2025-11-25** the latest supported version, while adding **2025-06-18** alongside existing supported versions.
- Refactored `ClientCapabilities` and `ServerCapabilities` into nested capability blocks, including explicit modeling for task-augmented tool-call support.

### Initialization and JSON-RPC request handling
- Improved MCP initialization request handling by preserving the incoming JSON-RPC `id` and cloning the initialization request payload more consistently.
- Generalized the initialization request construction for more flexible parameter handling.

### Tool call validation for task-augmented requests
- Server-side: added an explicit guard that rejects tool-call requests containing task-augmentation metadata (`params.task`) with a clear `INVALID_REQUEST` JSON-RPC error.
- Client-side: added an early capability check during `callTool` to fail fast with a clear error when the server does not advertise support for task-augmented tool calls.

### Data model and type system updates
- Updated and expanded MCP model types to match the revised protocol shape, including metadata/UI identity types (`BaseMetadata`, `Icon`, `Icons`), resource modeling (`Resource`, updated `ResourceLink`), and structured tool results (`ContentBlock` with union coverage).
- Extended tool execution modeling with new types (`TaskSupport`, `ToolExecution`) and updated tool definition/schema structures.
- Adjusted core request/parameter typing to use more flexible generic parameter shapes.

### Native-side type resolution robustness
- Improved native type resolution by using implied-type resolution when constructing tool/content records and validating expected shapes (e.g., union handling) to reduce assumptions about data representation.

### Test coverage
- Added/extended tests to validate initialization behavior with experimental capability inputs and extended implementation metadata.
- Added a dedicated type test suite covering updated model shapes, unions/discriminants, tool-call parameter/result modeling, and JSON-RPC response type expectations.

## Outcome

Overall, these changes improve compatibility and integration stability by supporting the updated MCP protocol version, ensuring initialization succeeds against APIM 4.6.0 environments, and providing clearer behavior when clients attempt unsupported task-augmented tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->