### PR TITLE
Add transport-specific MCP service types with HTTP header and request access

### DIFF
--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -30,7 +30,7 @@ def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/res
 def testCommonTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/BallerinaTestCommon.toml")
 def ballerinaDist = "${project.rootDir}/target/ballerina-runtime"
 def distributionBinPath =  "${ballerinaDist}/bin"
-def testCoverageParam = "--code-coverage --coverage-format=xml --includes=io.ballerina.lib.mcp.*:ballerina.*"
+def testCoverageParam = "--code-coverage --coverage-format=xml --includes=io.ballerina.stdlib.mcp.*:ballerina.*"
 def testSuites = ["mcp-ballerina-tests"]
 
 def stripBallerinaExtensionVersion(String extVersion) {

--- a/ballerina-tests/mcp-ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/mcp-ballerina-tests/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerinatests"
 name = "mcp_ballerina_tests"
-version = "1.1.0"
+version = "1.1.1"

--- a/ballerina-tests/mcp-ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/mcp-ballerina-tests/Ballerina.toml
@@ -1,4 +1,4 @@
 [package]
 org = "ballerinatests"
 name = "mcp_ballerina_tests"
-version = "1.1.1"
+version = "1.2.0"

--- a/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.11"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -101,6 +101,10 @@ dependencies = [
 	{org = "ballerina", name = "observe"},
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
+]
+modules = [
+	{org = "ballerina", packageName = "http", moduleName = "http"},
+	{org = "ballerina", packageName = "http", moduleName = "http.httpscerr"}
 ]
 
 [[package]]
@@ -256,7 +260,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -301,7 +305,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -326,7 +330,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.8.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -358,6 +362,7 @@ org = "ballerinatests"
 name = "mcp_ballerina_tests"
 version = "1.0.4"
 dependencies = [
+	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "mcp"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.1.1"
+version = "1.2.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 org = "ballerinatests"
 name = "mcp_ballerina_tests"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "mcp"},

--- a/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/mcp-ballerina-tests/Dependencies.toml
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.3"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.1"
+version = "2.14.11"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -110,7 +110,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -126,7 +126,7 @@ scope = "testOnly"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.15.0"
+version = "2.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.1.0"
+version = "1.1.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "http"},
@@ -260,7 +260,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -272,7 +272,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -286,7 +286,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.0"
+version = "1.5.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -360,7 +360,7 @@ dependencies = [
 [[package]]
 org = "ballerinatests"
 name = "mcp_ballerina_tests"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "mcp"},

--- a/ballerina-tests/mcp-ballerina-tests/tests/header_binding_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/header_binding_tests.bal
@@ -29,11 +29,11 @@ type TestCallerHeaders record {|
     string tenantId?;
 |};
 
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {name: "header-binding-test-server", version: "1.0.0"},
     sessionMode: mcp:STATELESS
 }
-isolated service mcp:Service /mcp on new mcp:Listener(8767) {
+isolated service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(8767) {
 
     @mcp:Tool {description: "Binds the authorization header by parameter name"}
     isolated remote function readAuth(@http:Header string authorization, string name) returns string {
@@ -73,12 +73,12 @@ isolated service mcp:Service /mcp on new mcp:Listener(8767) {
     }
 }
 
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {name: "strict-header-binding-test-server", version: "1.0.0"},
     sessionMode: mcp:STATELESS,
     httpConfig: {treatNilableAsOptional: false}
 }
-isolated service mcp:Service /mcp on new mcp:Listener(8768) {
+isolated service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(8768) {
 
     @mcp:Tool {description: "Nilable header under treatNilableAsOptional: false"}
     isolated remote function readStrictTenant(@http:Header {name: "X-Tenant-Id"} string? tenant) returns string {

--- a/ballerina-tests/mcp-ballerina-tests/tests/header_binding_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/header_binding_tests.bal
@@ -71,6 +71,12 @@ isolated service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListene
         string|http:HeaderNotFoundError auth = headers.getHeader("authorization");
         return auth is string ? auth : "<none>";
     }
+
+    @mcp:Tool {description: "Reads a header via the raw http:Request object"}
+    isolated remote function readViaRequest(http:Request request, string name) returns string {
+        string|http:HeaderNotFoundError auth = request.getHeader("authorization");
+        return name + ":" + (auth is string ? auth : "<none>");
+    }
 }
 
 @mcp:StreamableHttpServiceConfig {
@@ -242,6 +248,13 @@ function testRawHeadersParamBinding() returns error? {
     mcp:CallToolResult result = check headerClient->callTool(
         {name: "readRaw", arguments: {}}, {"authorization": "Bearer raw-token"});
     test:assertEquals(check getTextResult(result), "Bearer raw-token");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testRequestParamBinding() returns error? {
+    mcp:CallToolResult result = check headerClient->callTool(
+        {name: "readViaRequest", arguments: {"name": "World"}}, {"authorization": "Bearer req-token"});
+    test:assertEquals(check getTextResult(result), "World:Bearer req-token");
 }
 
 @test:Config {dependsOn: [testHeaderBindingClientInit]}

--- a/ballerina-tests/mcp-ballerina-tests/tests/header_binding_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/header_binding_tests.bal
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+import ballerina/test;
+
+enum TestApiVersion {
+    TV1 = "v1",
+    TV2 = "v2"
+}
+
+type TestCallerHeaders record {|
+    string authorization;
+    @http:Header {name: "X-Tenant-Id"}
+    string tenantId?;
+|};
+
+@mcp:ServiceConfig {
+    info: {name: "header-binding-test-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:Service /mcp on new mcp:Listener(8767) {
+
+    @mcp:Tool {description: "Binds the authorization header by parameter name"}
+    isolated remote function readAuth(@http:Header string authorization, string name) returns string {
+        return name + ":" + authorization;
+    }
+
+    @mcp:Tool {description: "Binds a named nilable header"}
+    isolated remote function readTenant(@http:Header {name: "X-Tenant-Id"} string? tenant) returns string {
+        return tenant ?: "<none>";
+    }
+
+    @mcp:Tool {description: "Binds typed headers"}
+    isolated remote function readTyped(@http:Header {name: "X-Retry-Count"} int retries,
+            @http:Header {name: "X-Debug"} boolean debug) returns string {
+        return retries.toString() + ":" + debug.toString();
+    }
+
+    @mcp:Tool {description: "Binds an enum header"}
+    isolated remote function readVersion(@http:Header {name: "X-Ver"} TestApiVersion ver) returns string {
+        return ver;
+    }
+
+    @mcp:Tool {description: "Binds a readonly header array"}
+    isolated remote function readTags(@http:Header {name: "X-Tag"} readonly & string[] tags) returns string {
+        return string:'join(",", ...tags);
+    }
+
+    @mcp:Tool {description: "Binds a record of headers"}
+    isolated remote function readRecord(@http:Header TestCallerHeaders hdrs) returns string {
+        return hdrs.authorization + ":" + (hdrs.tenantId ?: "<none>");
+    }
+
+    @mcp:Tool {description: "Reads the raw http:Headers object"}
+    isolated remote function readRaw(http:Headers headers) returns string {
+        string|http:HeaderNotFoundError auth = headers.getHeader("authorization");
+        return auth is string ? auth : "<none>";
+    }
+}
+
+@mcp:ServiceConfig {
+    info: {name: "strict-header-binding-test-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS,
+    httpConfig: {treatNilableAsOptional: false}
+}
+isolated service mcp:Service /mcp on new mcp:Listener(8768) {
+
+    @mcp:Tool {description: "Nilable header under treatNilableAsOptional: false"}
+    isolated remote function readStrictTenant(@http:Header {name: "X-Tenant-Id"} string? tenant) returns string {
+        return tenant ?: "<none>";
+    }
+}
+
+final mcp:StreamableHttpClient headerClient = check new ("http://localhost:8767/mcp");
+final mcp:StreamableHttpClient strictHeaderClient = check new ("http://localhost:8768/mcp");
+
+// Raw JSON-RPC client: the mcp client discards the JSON-RPC error payload of
+// non-2xx responses and cannot send string[] header values, so error-path and
+// multi-value-header tests go through plain http.
+final http:Client rawHeaderClient = check new ("http://localhost:8767");
+final http:Client rawStrictHeaderClient = check new ("http://localhost:8768");
+
+isolated function getTextResult(mcp:CallToolResult result) returns string|error {
+    mcp:TextContent textContent = check result.content[0].ensureType();
+    return textContent.text;
+}
+
+isolated function rawCallTool(http:Client rawClient, string toolName,
+        map<string|string[]> headers) returns json|error {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/call",
+        params: {name: toolName, arguments: {}}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    foreach var [headerName, value] in headers.entries() {
+        if value is string {
+            request.setHeader(headerName, value);
+        } else {
+            foreach string headerValue in value {
+                request.addHeader(headerName, headerValue);
+            }
+        }
+    }
+    http:Response response = check rawClient->post("/mcp", request);
+    return response.getJsonPayload();
+}
+
+isolated function getRawErrorMessage(json payload) returns string|error {
+    json message = check payload.'error.message;
+    return message.toString();
+}
+
+isolated function getRawErrorCode(json payload) returns int|error {
+    json code = check payload.'error.code;
+    return code.ensureType();
+}
+
+isolated function getRawTextResult(json payload) returns string|error {
+    json[] content = check (check payload.result.content).ensureType();
+    json text = check content[0].text;
+    return text.toString();
+}
+
+@test:Config
+function testHeaderBindingClientInit() returns error? {
+    check headerClient->initialize({name: "header-test-client", version: "1.0.0"});
+    check strictHeaderClient->initialize({name: "strict-header-test-client", version: "1.0.0"});
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testHeaderParamsExcludedFromSchema() returns error? {
+    mcp:ListToolsResult result = check headerClient->listTools();
+
+    foreach mcp:ToolDefinition tool in result.tools {
+        if tool.name != "readAuth" {
+            continue;
+        }
+        map<record {}> properties = check tool.inputSchema.properties.ensureType();
+        test:assertTrue(properties.hasKey("name"), msg = "tool argument must stay in the schema");
+        test:assertFalse(properties.hasKey("authorization"),
+            msg = "@http:Header parameter must be excluded from the tool input schema");
+        return;
+    }
+    test:assertFail("readAuth tool not found in tools/list");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testSingleHeaderBinding() returns error? {
+    mcp:CallToolResult result = check headerClient->callTool(
+        {name: "readAuth", arguments: {"name": "World"}},
+        {"authorization": "Bearer test-token"});
+    test:assertEquals(check getTextResult(result), "World:Bearer test-token");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testMissingRequiredHeader() returns error? {
+    json payload = check rawCallTool(rawHeaderClient, "readAuth", {});
+    string message = check getRawErrorMessage(payload);
+    test:assertTrue(message.includes("no header value found for 'authorization'"),
+        msg = "unexpected error: " + message);
+    test:assertEquals(check getRawErrorCode(payload), -32602,
+        msg = "binding failures must be reported as invalid params");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testNilableHeaderPresentAndMissing() returns error? {
+    mcp:CallToolResult withHeader = check headerClient->callTool(
+        {name: "readTenant", arguments: {}}, {"X-Tenant-Id": "tenant-42"});
+    test:assertEquals(check getTextResult(withHeader), "tenant-42");
+
+    mcp:CallToolResult withoutHeader = check headerClient->callTool({name: "readTenant", arguments: {}});
+    test:assertEquals(check getTextResult(withoutHeader), "<none>");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testTypedHeaderBinding() returns error? {
+    mcp:CallToolResult result = check headerClient->callTool(
+        {name: "readTyped", arguments: {}},
+        {"X-Retry-Count": "3", "X-Debug": "true"});
+    test:assertEquals(check getTextResult(result), "3:true");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testTypedHeaderCastFailure() returns error? {
+    json payload = check rawCallTool(rawHeaderClient, "readTyped",
+        {"X-Retry-Count": "not-a-number", "X-Debug": "true"});
+    string message = check getRawErrorMessage(payload);
+    test:assertTrue(message.includes("header binding failed for parameter 'X-Retry-Count'"),
+        msg = "unexpected error: " + message);
+    test:assertEquals(check getRawErrorCode(payload), -32602,
+        msg = "binding failures must be reported as invalid params");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testEnumHeaderBinding() returns error? {
+    mcp:CallToolResult valid = check headerClient->callTool(
+        {name: "readVersion", arguments: {}}, {"X-Ver": "v2"});
+    test:assertEquals(check getTextResult(valid), "v2");
+
+    json invalid = check rawCallTool(rawHeaderClient, "readVersion", {"X-Ver": "v9"});
+    string message = check getRawErrorMessage(invalid);
+    test:assertTrue(message.includes("header binding failed for parameter 'X-Ver'"),
+        msg = "unexpected error: " + message);
+    test:assertEquals(check getRawErrorCode(invalid), -32602,
+        msg = "binding failures must be reported as invalid params");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testReadonlyArrayHeaderBinding() returns error? {
+    json payload = check rawCallTool(rawHeaderClient, "readTags", {"X-Tag": ["alpha", "beta"]});
+    test:assertEquals(check getRawTextResult(payload), "alpha,beta");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testHeaderRecordBinding() returns error? {
+    mcp:CallToolResult full = check headerClient->callTool(
+        {name: "readRecord", arguments: {}},
+        {"authorization": "Bearer rec-token", "X-Tenant-Id": "tenant-7"});
+    test:assertEquals(check getTextResult(full), "Bearer rec-token:tenant-7");
+
+    mcp:CallToolResult partial = check headerClient->callTool(
+        {name: "readRecord", arguments: {}}, {"authorization": "Bearer rec-token"});
+    test:assertEquals(check getTextResult(partial), "Bearer rec-token:<none>");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testRawHeadersParamBinding() returns error? {
+    mcp:CallToolResult result = check headerClient->callTool(
+        {name: "readRaw", arguments: {}}, {"authorization": "Bearer raw-token"});
+    test:assertEquals(check getTextResult(result), "Bearer raw-token");
+}
+
+@test:Config {dependsOn: [testHeaderBindingClientInit]}
+function testStrictNilableHeaderMissing() returns error? {
+    json payload = check rawCallTool(rawStrictHeaderClient, "readStrictTenant", {});
+    string message = check getRawErrorMessage(payload);
+    test:assertTrue(message.includes("no header value found for 'X-Tenant-Id'"),
+        msg = "unexpected error: " + message);
+    test:assertEquals(check getRawErrorCode(payload), -32602,
+        msg = "binding failures must be reported as invalid params");
+}

--- a/ballerina-tests/mcp-ballerina-tests/tests/listener_naming_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/listener_naming_tests.bal
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+import ballerina/test;
+
+// Streamable HTTP service configured through the transport-specific
+// @mcp:StreamableHttpServiceConfig annotation; header binding is allowed here.
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "transport-named-listener-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS,
+    httpConfig: {treatNilableAsOptional: false}
+}
+isolated service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(8769) {
+
+    @mcp:Tool {description: "Header binding on the Streamable HTTP service"}
+    isolated remote function greet(@http:Header string authorization, string name) returns string {
+        return name + ":" + authorization;
+    }
+
+    @mcp:Tool {description: "Nilable header under strict mode set via @mcp:StreamableHttpServiceConfig"}
+    isolated remote function tenant(@http:Header {name: "X-Tenant-Id"} string? tenant) returns string {
+        return tenant ?: "<none>";
+    }
+}
+
+// Precedence: @mcp:StreamableHttpServiceConfig is the configuration home for a Streamable HTTP
+// service and must take precedence over the deprecated sessionMode field of @mcp:ServiceConfig
+// (STATEFUL below would otherwise reject session-less calls).
+@mcp:ServiceConfig {
+    info: {name: "transport-config-precedence-server", version: "1.0.0"},
+    sessionMode: mcp:STATEFUL
+}
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "transport-config-precedence-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(8770) {
+
+    @mcp:Tool {description: "Returns a fixed value"}
+    isolated remote function echo() returns string {
+        return "ok";
+    }
+}
+
+final http:Client rawTransportClient = check new ("http://localhost:8769");
+final http:Client rawPrecedenceClient = check new ("http://localhost:8770");
+
+@test:Config
+function testHeaderBindingOnStreamableHttpListener() returns error? {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/call",
+        params: {name: "greet", arguments: {"name": "World"}}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    request.setHeader("authorization", "Bearer shl-token");
+    http:Response response = check rawTransportClient->post("/mcp", request);
+    json result = check response.getJsonPayload();
+    test:assertEquals(check getRawTextResult(result), "World:Bearer shl-token");
+}
+
+@test:Config
+function testStrictModeViaTransportConfigAnnotation() returns error? {
+    // treatNilableAsOptional=false comes from @mcp:StreamableHttpConfig.httpConfig:
+    // a missing nilable header must be rejected as invalid params
+    json payload = check rawCallTool(rawTransportClient, "tenant", {});
+    string message = check getRawErrorMessage(payload);
+    test:assertTrue(message.includes("no header value found for 'X-Tenant-Id'"),
+        msg = "unexpected error: " + message);
+    test:assertEquals(check getRawErrorCode(payload), -32602);
+
+    json withHeader = check rawCallTool(rawTransportClient, "tenant", {"X-Tenant-Id": "t-1"});
+    test:assertEquals(check getRawTextResult(withHeader), "t-1");
+}
+
+@test:Config
+function testTransportConfigSessionModePrecedence() returns error? {
+    // No initialize handshake and no mcp-session-id header: only works if the effective
+    // session mode is STATELESS, i.e. @mcp:StreamableHttpConfig overrode @mcp:ServiceConfig
+    json payload = check rawCallTool(rawPrecedenceClient, "echo", {});
+    json|error errorField = payload.'error;
+    if errorField is json {
+        test:assertFail("expected STATELESS behavior from @mcp:StreamableHttpConfig precedence, got: "
+            + errorField.toString());
+    }
+}

--- a/ballerina-tests/mcp-ballerina-tests/tests/listener_naming_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/listener_naming_tests.bal
@@ -74,7 +74,7 @@ function testHeaderBindingOnStreamableHttpListener() returns error? {
 
 @test:Config
 function testStrictModeViaTransportConfigAnnotation() returns error? {
-    // treatNilableAsOptional=false comes from @mcp:StreamableHttpConfig.httpConfig:
+    // treatNilableAsOptional=false comes from @mcp:StreamableHttpServiceConfig.httpConfig:
     // a missing nilable header must be rejected as invalid params
     json payload = check rawCallTool(rawTransportClient, "tenant", {});
     string message = check getRawErrorMessage(payload);
@@ -89,11 +89,12 @@ function testStrictModeViaTransportConfigAnnotation() returns error? {
 @test:Config
 function testTransportConfigSessionModePrecedence() returns error? {
     // No initialize handshake and no mcp-session-id header: only works if the effective
-    // session mode is STATELESS, i.e. @mcp:StreamableHttpConfig overrode @mcp:ServiceConfig
+    // session mode is STATELESS, i.e. @mcp:StreamableHttpServiceConfig overrode @mcp:ServiceConfig
     json payload = check rawCallTool(rawPrecedenceClient, "echo", {});
     json|error errorField = payload.'error;
     if errorField is json {
-        test:assertFail("expected STATELESS behavior from @mcp:StreamableHttpConfig precedence, got: "
+        test:assertFail("expected STATELESS behavior from @mcp:StreamableHttpServiceConfig precedence, got: "
             + errorField.toString());
     }
+    test:assertEquals(check getRawTextResult(payload), "ok");
 }

--- a/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
@@ -28,12 +28,13 @@ isolated service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHtt
 
     isolated remote function onListTools(@http:Header {name: "X-Tools-Filter"} string? filter)
             returns mcp:ListToolsResult|mcp:ServerError {
-        string toolName = filter ?: "whoAmI";
-        return {
-            tools: [
-                {name: toolName, description: "Returns the Authorization header", inputSchema: {'type: "object"}}
-            ]
-        };
+        // Echo the bound @http:Header value back via an error so the test can verify header
+        // binding on onListTools. (A returned ToolDefinition would require constructing the
+        // inputSchema record, which is currently not constructible in user code at runtime.)
+        if filter is string {
+            return error mcp:ServerError(string `filter:${filter}`);
+        }
+        return {tools: []};
     }
 
     isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session,
@@ -50,16 +51,17 @@ final http:Client rawAdvancedClient = check new ("http://localhost:8771");
 
 @test:Config
 function testStreamableHttpAdvancedServiceListTools() returns error? {
-    // onListTools binds an @http:Header parameter to choose the listed tool name.
+    // onListTools binds an @http:Header parameter; the service echoes it back so we can confirm
+    // the header was bound and received.
     http:Request request = new;
     request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/list", params: {}});
     request.setHeader("Accept", "application/json, text/event-stream");
     request.setHeader("X-Tools-Filter", "filteredTool");
     http:Response response = check rawAdvancedClient->post("/mcp", request);
     json result = check response.getJsonPayload();
-    json[] tools = check (check result.result.tools).ensureType();
-    test:assertEquals(tools.length(), 1);
-    test:assertEquals(check tools[0].name, "filteredTool");
+    json message = check result.'error.message;
+    test:assertTrue(message.toString().includes("filter:filteredTool"),
+            msg = "expected the bound X-Tools-Filter header to be echoed, found: " + message.toString());
 }
 
 @test:Config

--- a/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+import ballerina/test;
+
+// An advanced Streamable HTTP service: onCallTool additionally receives the request headers.
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "advanced-http-server", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(8771) {
+
+    isolated remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {
+            tools: [
+                {name: "whoAmI", description: "Returns the Authorization header", inputSchema: {'type: "object"}}
+            ]
+        };
+    }
+
+    isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session, http:Headers headers)
+            returns mcp:CallToolResult|mcp:ServerError {
+        string|http:HeaderNotFoundError auth = headers.getHeader("Authorization");
+        return {content: [{'type: "text", text: auth is string ? auth : "<none>"}]};
+    }
+}
+
+final http:Client rawAdvancedClient = check new ("http://localhost:8771");
+
+@test:Config
+function testStreamableHttpAdvancedServiceListTools() returns error? {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/list", params: {}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check rawAdvancedClient->post("/mcp", request);
+    json result = check response.getJsonPayload();
+    json[] tools = check (check result.result.tools).ensureType();
+    test:assertEquals(tools.length(), 1);
+    test:assertEquals(check tools[0].name, "whoAmI");
+}
+
+@test:Config
+function testStreamableHttpAdvancedServiceHeaderAccess() returns error? {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 2, method: "tools/call",
+        params: {name: "whoAmI", arguments: {}}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    request.setHeader("Authorization", "Bearer adv-token");
+    http:Response response = check rawAdvancedClient->post("/mcp", request);
+    json result = check response.getJsonPayload();
+    test:assertEquals(check getRawTextResult(result), "Bearer adv-token");
+}

--- a/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
@@ -18,25 +18,31 @@ import ballerina/http;
 import ballerina/mcp;
 import ballerina/test;
 
-// An advanced Streamable HTTP service: onCallTool additionally receives the underlying http:Request.
+// An advanced Streamable HTTP service whose onListTools/onCallTool bind transport-specific request
+// information the same way StreamableHttpService tools do: @http:Header, http:Headers, http:Request.
 @mcp:StreamableHttpServiceConfig {
     info: {name: "advanced-http-server", version: "1.0.0"},
     sessionMode: mcp:STATELESS
 }
 isolated service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(8771) {
 
-    isolated remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+    isolated remote function onListTools(@http:Header {name: "X-Tools-Filter"} string? filter)
+            returns mcp:ListToolsResult|mcp:ServerError {
+        string toolName = filter ?: "whoAmI";
         return {
             tools: [
-                {name: "whoAmI", description: "Returns the Authorization header", inputSchema: {'type: "object"}}
+                {name: toolName, description: "Returns the Authorization header", inputSchema: {'type: "object"}}
             ]
         };
     }
 
-    isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session, http:Request request)
+    isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session,
+            @http:Header {name: "Authorization"} string? auth, http:Headers headers)
             returns mcp:CallToolResult|mcp:ServerError {
-        string|http:HeaderNotFoundError auth = request.getHeader("Authorization");
-        return {content: [{'type: "text", text: auth is string ? auth : "<none>"}]};
+        string viaAnnotation = auth ?: "<none>";
+        string|http:HeaderNotFoundError traceHeader = headers.getHeader("X-Trace");
+        string trace = traceHeader is string ? traceHeader : "<none>";
+        return {content: [{'type: "text", text: viaAnnotation + "|" + trace}]};
     }
 }
 
@@ -44,24 +50,28 @@ final http:Client rawAdvancedClient = check new ("http://localhost:8771");
 
 @test:Config
 function testStreamableHttpAdvancedServiceListTools() returns error? {
+    // onListTools binds an @http:Header parameter to choose the listed tool name.
     http:Request request = new;
     request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/list", params: {}});
     request.setHeader("Accept", "application/json, text/event-stream");
+    request.setHeader("X-Tools-Filter", "filteredTool");
     http:Response response = check rawAdvancedClient->post("/mcp", request);
     json result = check response.getJsonPayload();
     json[] tools = check (check result.result.tools).ensureType();
     test:assertEquals(tools.length(), 1);
-    test:assertEquals(check tools[0].name, "whoAmI");
+    test:assertEquals(check tools[0].name, "filteredTool");
 }
 
 @test:Config
 function testStreamableHttpAdvancedServiceHeaderAccess() returns error? {
+    // onCallTool binds an @http:Header parameter and the raw http:Headers object simultaneously.
     http:Request request = new;
     request.setJsonPayload({jsonrpc: "2.0", id: 2, method: "tools/call",
         params: {name: "whoAmI", arguments: {}}});
     request.setHeader("Accept", "application/json, text/event-stream");
     request.setHeader("Authorization", "Bearer adv-token");
+    request.setHeader("X-Trace", "trace-123");
     http:Response response = check rawAdvancedClient->post("/mcp", request);
     json result = check response.getJsonPayload();
-    test:assertEquals(check getRawTextResult(result), "Bearer adv-token");
+    test:assertEquals(check getRawTextResult(result), "Bearer adv-token|trace-123");
 }

--- a/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/mcp;
 import ballerina/test;
 
-// An advanced Streamable HTTP service: onCallTool additionally receives the request headers.
+// An advanced Streamable HTTP service: onCallTool additionally receives the underlying http:Request.
 @mcp:StreamableHttpServiceConfig {
     info: {name: "advanced-http-server", version: "1.0.0"},
     sessionMode: mcp:STATELESS
@@ -33,9 +33,9 @@ isolated service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHtt
         };
     }
 
-    isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session, http:Headers headers)
+    isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session, http:Request request)
             returns mcp:CallToolResult|mcp:ServerError {
-        string|http:HeaderNotFoundError auth = headers.getHeader("Authorization");
+        string|http:HeaderNotFoundError auth = request.getHeader("Authorization");
         return {content: [{'type: "text", text: auth is string ? auth : "<none>"}]};
     }
 }

--- a/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/streamable_http_advanced_service_test.bal
@@ -28,13 +28,12 @@ isolated service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHtt
 
     isolated remote function onListTools(@http:Header {name: "X-Tools-Filter"} string? filter)
             returns mcp:ListToolsResult|mcp:ServerError {
-        // Echo the bound @http:Header value back via an error so the test can verify header
-        // binding on onListTools. (A returned ToolDefinition would require constructing the
-        // inputSchema record, which is currently not constructible in user code at runtime.)
-        if filter is string {
-            return error mcp:ServerError(string `filter:${filter}`);
-        }
-        return {tools: []};
+        string toolName = filter ?: "whoAmI";
+        return {
+            tools: [
+                {name: toolName, description: "Returns the Authorization header", inputSchema: {'type: "object"}}
+            ]
+        };
     }
 
     isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session,
@@ -51,17 +50,16 @@ final http:Client rawAdvancedClient = check new ("http://localhost:8771");
 
 @test:Config
 function testStreamableHttpAdvancedServiceListTools() returns error? {
-    // onListTools binds an @http:Header parameter; the service echoes it back so we can confirm
-    // the header was bound and received.
+    // onListTools binds an @http:Header parameter to choose the listed tool name.
     http:Request request = new;
     request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/list", params: {}});
     request.setHeader("Accept", "application/json, text/event-stream");
     request.setHeader("X-Tools-Filter", "filteredTool");
     http:Response response = check rawAdvancedClient->post("/mcp", request);
     json result = check response.getJsonPayload();
-    json message = check result.'error.message;
-    test:assertTrue(message.toString().includes("filter:filteredTool"),
-            msg = "expected the bound X-Tools-Filter header to be echoed, found: " + message.toString());
+    json[] tools = check (check result.result.tools).ensureType();
+    test:assertEquals(tools.length(), 1);
+    test:assertEquals(check tools[0].name, "filteredTool");
 }
 
 @test:Config

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "mcp"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Ballerina"]
 keywords = ["mcp"]
 repository = "https://github.com/ballerina-platform/module-ballerina-mcp"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib."
 artifactId = "mcp-native"
-version = "1.1.1"
-path = "../native/build/libs/mcp-native-1.1.1-SNAPSHOT.jar"
+version = "1.2.0"
+path = "../native/build/libs/mcp-native-1.2.0-SNAPSHOT.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "mcp"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Ballerina"]
 keywords = ["mcp"]
 repository = "https://github.com/ballerina-platform/module-ballerina-mcp"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib."
 artifactId = "mcp-native"
-version = "1.1.0"
-path = "../native/build/libs/mcp-native-1.1.0.jar"
+version = "1.1.1"
+path = "../native/build/libs/mcp-native-1.1.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "mcp-compiler-plugin"
 class = "io.ballerina.stdlib.mcp.plugin.McpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mcp-compiler-plugin-1.1.0.jar"
+path = "../compiler-plugin/build/libs/mcp-compiler-plugin-1.1.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "mcp-compiler-plugin"
 class = "io.ballerina.stdlib.mcp.plugin.McpCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/mcp-compiler-plugin-1.1.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/mcp-compiler-plugin-1.2.0-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.1"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.9.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.11"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -103,7 +103,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.1"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -120,7 +120,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.15.1"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -229,7 +229,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.2"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.1"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.1"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.2"
+version = "2.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -26,11 +26,11 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
         ...httpServiceConfig
     } isolated service object {
         private map<Session> sessionMap = {};
-        private ServiceConfiguration? cachedServiceConfig = ();
+        private StreamableHttpServiceConfiguration? cachedServiceConfig = ();
 
         isolated resource function delete .(http:Headers headers) returns http:BadRequest|http:Ok|Error {
             http:authenticateResource(self, "delete", []);
-            ServiceConfiguration config = check self.getCachedServiceConfiguration();
+            StreamableHttpServiceConfiguration config = check self.getCachedServiceConfiguration();
             SessionMode sessionMode = config.sessionMode;
 
             if sessionMode == STATELESS {
@@ -87,13 +87,14 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             };
         }
 
-        private isolated function getCachedServiceConfiguration() returns ServiceConfiguration|Error {
+        private isolated function getCachedServiceConfiguration() returns StreamableHttpServiceConfiguration|Error {
             lock {
                 if self.cachedServiceConfig is () {
-                    Service|AdvancedService mcpService = check getMcpServiceFromDispatcher(self);
+                    Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService =
+                            check getMcpServiceFromDispatcher(self);
                     self.cachedServiceConfig = getServiceConfiguration(mcpService);
                 }
-                return <ServiceConfiguration>self.cachedServiceConfig.clone();
+                return <StreamableHttpServiceConfiguration>self.cachedServiceConfig.clone();
             }
         }
 
@@ -145,7 +146,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 };
             }
 
-            ServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
+            StreamableHttpServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
             SessionMode effectiveSessionMode = determineEffectiveSessionMode(serviceConfig, headers, REQUEST_INITIALIZE);
 
             string requestedVersion = initRequest.params.protocolVersion;
@@ -197,7 +198,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
 
         private isolated function handleListToolsRequest(JsonRpcRequest request, http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
-            ServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
+            StreamableHttpServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
             SessionMode effectiveSessionMode = determineEffectiveSessionMode(serviceConfig, headers, REQUEST_LIST_TOOLS);
 
             string? sessionId = ();
@@ -243,7 +244,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
 
         private isolated function handleCallToolRequest(JsonRpcRequest request, http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
-            ServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
+            StreamableHttpServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
             SessionMode effectiveSessionMode = determineEffectiveSessionMode(serviceConfig, headers, REQUEST_CALL_TOOL);
 
             string? sessionId = ();
@@ -313,11 +314,12 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
         }
 
         private isolated function executeOnListTools() returns ListToolsResult|Error {
-            Service|AdvancedService mcpService = check getMcpServiceFromDispatcher(self);
-            if mcpService is AdvancedService {
+            Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService =
+                    check getMcpServiceFromDispatcher(self);
+            if mcpService is AdvancedService|StreamableHttpAdvancedService {
                 return invokeOnListTools(mcpService);
             }
-            if mcpService is Service {
+            if mcpService is Service|StreamableHttpService {
                 return listToolsForRemoteFunctions(mcpService);
             }
             return error DispatcherError("MCP Service is not attached");
@@ -325,11 +327,15 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
 
         private isolated function executeOnCallTool(CallToolParams params, Session? session, http:Headers headers,
                 boolean treatNilableAsOptional) returns CallToolResult|Error {
-            Service|AdvancedService mcpService = check getMcpServiceFromDispatcher(self);
+            Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService =
+                    check getMcpServiceFromDispatcher(self);
+            if mcpService is StreamableHttpAdvancedService {
+                return invokeOnCallToolWithHeaders(mcpService, params.cloneReadOnly(), session, headers);
+            }
             if mcpService is AdvancedService {
                 return invokeOnCallTool(mcpService, params.cloneReadOnly(), session);
             }
-            if mcpService is Service {
+            if mcpService is Service|StreamableHttpService {
                 CallToolResult|error result = callToolForRemoteFunctions(mcpService, params.cloneReadOnly(), session,
                         headers, extractHeaderValues(headers), treatNilableAsOptional);
                 if result is ParameterBindingError {

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -280,7 +280,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 session = sessionId is string ? self.sessionMap[sessionId] : ();
             }
 
-            CallToolResult|error callToolResult = self.executeOnCallTool(params, session);
+            CallToolResult|error callToolResult = self.executeOnCallTool(params, session, headers);
             if callToolResult is error {
                 return <http:BadRequest>{
                     body: createJsonRpcError(INTERNAL_ERROR,
@@ -320,14 +320,15 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             return error DispatcherError("MCP Service is not attached");
         }
 
-        private isolated function executeOnCallTool(CallToolParams params, Session? session)
+        private isolated function executeOnCallTool(CallToolParams params, Session? session, http:Headers headers)
                 returns CallToolResult|Error {
             Service|AdvancedService mcpService = check getMcpServiceFromDispatcher(self);
             if mcpService is AdvancedService {
                 return invokeOnCallTool(mcpService, params.cloneReadOnly(), session);
             }
             if mcpService is Service {
-                CallToolResult|error result = callToolForRemoteFunctions(mcpService, params.cloneReadOnly(), session);
+                CallToolResult|error result = callToolForRemoteFunctions(mcpService, params.cloneReadOnly(), session,
+                        headers);
                 if result is error {
                     return error DispatcherError(result.message());
                 }

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -107,7 +107,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                     return self.handleInitializeRequest(request, headers);
                 }
                 REQUEST_LIST_TOOLS => {
-                    return self.handleListToolsRequest(request, headers);
+                    return self.handleListToolsRequest(request, httpRequest, headers);
                 }
                 REQUEST_CALL_TOOL => {
                     return self.handleCallToolRequest(request, httpRequest, headers);
@@ -198,7 +198,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             }
         }
 
-        private isolated function handleListToolsRequest(JsonRpcRequest request, http:Headers headers)
+        private isolated function handleListToolsRequest(JsonRpcRequest request, http:Request httpRequest,
+                http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
             StreamableHttpServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
             SessionMode effectiveSessionMode = determineEffectiveSessionMode(serviceConfig, headers, REQUEST_LIST_TOOLS);
@@ -224,8 +225,16 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 }
             }
 
-            ListToolsResult|error listToolsResult = self.executeOnListTools();
+            ListToolsResult|error listToolsResult = self.executeOnListTools(headers, httpRequest,
+                    serviceConfig.httpConfig.treatNilableAsOptional);
             if listToolsResult is error {
+                // Parameter binding failures are caller errors, reported as invalid params
+                if listToolsResult is ParameterBindingError {
+                    return <http:BadRequest>{
+                        body: createJsonRpcError(INVALID_PARAMS,
+                                string `Failed to list tools: ${listToolsResult.message()}`, request.id)
+                    };
+                }
                 return <http:BadRequest>{
                     body: createJsonRpcError(INTERNAL_ERROR,
                             string `Failed to list tools: ${listToolsResult.message()}`, request.id)
@@ -316,10 +325,15 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             return LATEST_PROTOCOL_VERSION;
         }
 
-        private isolated function executeOnListTools() returns ListToolsResult|Error {
+        private isolated function executeOnListTools(http:Headers headers, http:Request httpRequest,
+                boolean treatNilableAsOptional) returns ListToolsResult|Error {
             Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService =
                     check getMcpServiceFromDispatcher(self);
-            if mcpService is AdvancedService|StreamableHttpAdvancedService {
+            if mcpService is StreamableHttpAdvancedService {
+                return invokeAdvancedOnListTools(mcpService, headers, httpRequest, extractHeaderValues(headers),
+                        treatNilableAsOptional);
+            }
+            if mcpService is AdvancedService {
                 return invokeOnListTools(mcpService);
             }
             if mcpService is Service|StreamableHttpService {
@@ -333,7 +347,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService =
                     check getMcpServiceFromDispatcher(self);
             if mcpService is StreamableHttpAdvancedService {
-                return invokeOnCallToolWithRequest(mcpService, params.cloneReadOnly(), session, httpRequest);
+                return invokeAdvancedOnCallTool(mcpService, params.cloneReadOnly(), session, headers, httpRequest,
+                        extractHeaderValues(headers), treatNilableAsOptional);
             }
             if mcpService is AdvancedService {
                 return invokeOnCallTool(mcpService, params.cloneReadOnly(), session);

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -280,10 +280,13 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 session = sessionId is string ? self.sessionMap[sessionId] : ();
             }
 
-            CallToolResult|error callToolResult = self.executeOnCallTool(params, session, headers);
+            CallToolResult|error callToolResult = self.executeOnCallTool(params, session, headers,
+                    serviceConfig.httpConfig.treatNilableAsOptional);
             if callToolResult is error {
+                // Parameter binding failures are caller errors, reported as invalid params
+                int errorCode = callToolResult is ParameterBindingError ? INVALID_PARAMS : INTERNAL_ERROR;
                 return <http:BadRequest>{
-                    body: createJsonRpcError(INTERNAL_ERROR,
+                    body: createJsonRpcError(errorCode,
                             string `Failed to call tool '${params.name}': ${callToolResult.message()}`, request.id)
                 };
             }
@@ -320,15 +323,18 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             return error DispatcherError("MCP Service is not attached");
         }
 
-        private isolated function executeOnCallTool(CallToolParams params, Session? session, http:Headers headers)
-                returns CallToolResult|Error {
+        private isolated function executeOnCallTool(CallToolParams params, Session? session, http:Headers headers,
+                boolean treatNilableAsOptional) returns CallToolResult|Error {
             Service|AdvancedService mcpService = check getMcpServiceFromDispatcher(self);
             if mcpService is AdvancedService {
                 return invokeOnCallTool(mcpService, params.cloneReadOnly(), session);
             }
             if mcpService is Service {
                 CallToolResult|error result = callToolForRemoteFunctions(mcpService, params.cloneReadOnly(), session,
-                        headers);
+                        headers, extractHeaderValues(headers), treatNilableAsOptional);
+                if result is ParameterBindingError {
+                    return result;
+                }
                 if result is error {
                     return error DispatcherError(result.message());
                 }

--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -66,7 +66,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             };
         }
 
-        isolated resource function post .(@http:Payload JsonRpcMessage request, http:Headers headers)
+        isolated resource function post .(@http:Payload JsonRpcMessage request, http:Request httpRequest,
+                http:Headers headers)
                 returns http:BadRequest|http:NotAcceptable|http:UnsupportedMediaType|http:Accepted|http:Ok|Error {
             http:authenticateResource(self, "post", []);
             http:NotAcceptable|http:UnsupportedMediaType? headerValidationError = validateRequiredHeaders(headers);
@@ -75,7 +76,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             }
 
             if request is JsonRpcRequest {
-                return self.processJsonRpcRequest(request, headers);
+                return self.processJsonRpcRequest(request, httpRequest, headers);
             }
 
             if request is JsonRpcNotification {
@@ -98,7 +99,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             }
         }
 
-        private isolated function processJsonRpcRequest(JsonRpcRequest request, http:Headers headers)
+        private isolated function processJsonRpcRequest(JsonRpcRequest request, http:Request httpRequest,
+                http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
             match request.method {
                 REQUEST_INITIALIZE => {
@@ -108,7 +110,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                     return self.handleListToolsRequest(request, headers);
                 }
                 REQUEST_CALL_TOOL => {
-                    return self.handleCallToolRequest(request, headers);
+                    return self.handleCallToolRequest(request, httpRequest, headers);
                 }
                 _ => {
                     return <http:BadRequest>{
@@ -242,7 +244,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
             };
         }
 
-        private isolated function handleCallToolRequest(JsonRpcRequest request, http:Headers headers)
+        private isolated function handleCallToolRequest(JsonRpcRequest request, http:Request httpRequest,
+                http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
             StreamableHttpServiceConfiguration serviceConfig = check self.getCachedServiceConfiguration();
             SessionMode effectiveSessionMode = determineEffectiveSessionMode(serviceConfig, headers, REQUEST_CALL_TOOL);
@@ -281,7 +284,7 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
                 session = sessionId is string ? self.sessionMap[sessionId] : ();
             }
 
-            CallToolResult|error callToolResult = self.executeOnCallTool(params, session, headers,
+            CallToolResult|error callToolResult = self.executeOnCallTool(params, session, headers, httpRequest,
                     serviceConfig.httpConfig.treatNilableAsOptional);
             if callToolResult is error {
                 // Parameter binding failures are caller errors, reported as invalid params
@@ -326,18 +329,18 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
         }
 
         private isolated function executeOnCallTool(CallToolParams params, Session? session, http:Headers headers,
-                boolean treatNilableAsOptional) returns CallToolResult|Error {
+                http:Request httpRequest, boolean treatNilableAsOptional) returns CallToolResult|Error {
             Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService =
                     check getMcpServiceFromDispatcher(self);
             if mcpService is StreamableHttpAdvancedService {
-                return invokeOnCallToolWithHeaders(mcpService, params.cloneReadOnly(), session, headers);
+                return invokeOnCallToolWithRequest(mcpService, params.cloneReadOnly(), session, httpRequest);
             }
             if mcpService is AdvancedService {
                 return invokeOnCallTool(mcpService, params.cloneReadOnly(), session);
             }
             if mcpService is Service|StreamableHttpService {
                 CallToolResult|error result = callToolForRemoteFunctions(mcpService, params.cloneReadOnly(), session,
-                        headers, extractHeaderValues(headers), treatNilableAsOptional);
+                        headers, httpRequest, extractHeaderValues(headers), treatNilableAsOptional);
                 if result is ParameterBindingError {
                     return result;
                 }

--- a/ballerina/error.bal
+++ b/ballerina/error.bal
@@ -85,3 +85,7 @@ public type ServerError distinct Error;
 
 # Custom error type for dispatcher service operations.
 type DispatcherError distinct ServerError;
+
+# Error for failures while binding tool parameters from the incoming request,
+# such as missing or invalid header values.
+public type ParameterBindingError distinct ServerError;

--- a/ballerina/listener.bal
+++ b/ballerina/listener.bal
@@ -21,8 +21,8 @@ public type ListenerConfiguration record {|
     *http:ListenerConfiguration;
 |};
 
-# A server listener for handling MCP service requests.
-public isolated class Listener {
+# A Streamable HTTP transport listener for handling MCP service requests.
+public isolated class StreamableHttpListener {
     private http:Listener httpListener;
     private DispatcherService[] dispatcherServices = [];
 
@@ -48,7 +48,7 @@ public isolated class Listener {
     # + mcpService - Service to attach.
     # + name - Path(s) to mount the service on (string or string array).
     # + return - Error? if attachment fails.
-    public isolated function attach(Service|AdvancedService mcpService, string[]|string? name = ()) returns Error? {
+    public isolated function attach(Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService, string[]|string? name = ()) returns Error? {
         http:HttpServiceConfig httpServiceConfig = getServiceConfiguration(mcpService).httpConfig;
         DispatcherService dispatcherService = getDispatcherService(httpServiceConfig);
         check addMcpServiceToDispatcher(dispatcherService, mcpService);
@@ -65,10 +65,10 @@ public isolated class Listener {
     #
     # + mcpService - Service to detach.
     # + return - Error? if detachment fails.
-    public isolated function detach(Service|AdvancedService mcpService) returns Error? {
+    public isolated function detach(Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService) returns Error? {
         lock {
             foreach [int, DispatcherService] [index, dispatcherService] in self.dispatcherServices.enumerate() {
-                Service|AdvancedService|Error attachedService = getMcpServiceFromDispatcher(dispatcherService);
+                Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService|Error attachedService = getMcpServiceFromDispatcher(dispatcherService);
                 if attachedService === mcpService {
                     error? result = self.httpListener.detach(dispatcherService);
                     if result is error {
@@ -116,4 +116,51 @@ public isolated class Listener {
             }
         }
     }
+}
+
+# A server listener for handling MCP service requests.
+#
+# # Deprecated
+# This listener is renamed to make the transport explicit. Use `mcp:StreamableHttpListener` instead.
+@deprecated
+public isolated class Listener {
+    private final StreamableHttpListener inner;
+
+    # Initializes the Listener.
+    #
+    # + listenTo - Either a port number (int) or an existing http:Listener.
+    # + config - Listener configuration.
+    # + return - Error? if listener initialization fails.
+    public function init(int|http:Listener listenTo, *ListenerConfiguration config) returns Error? {
+        self.inner = check new (listenTo, config);
+    }
+
+    # Attaches an MCP service to the listener under the specified path(s).
+    #
+    # + mcpService - Service to attach.
+    # + name - Path(s) to mount the service on (string or string array).
+    # + return - Error? if attachment fails.
+    public isolated function attach(Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService, string[]|string? name = ()) returns Error? =>
+        self.inner.attach(mcpService, name);
+
+    # Detaches the MCP service from the listener.
+    #
+    # + mcpService - Service to detach.
+    # + return - Error? if detachment fails.
+    public isolated function detach(Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService) returns Error? => self.inner.detach(mcpService);
+
+    # Starts the listener (begin accepting connections).
+    #
+    # + return - Error? if starting fails.
+    public isolated function 'start() returns Error? => self.inner.'start();
+
+    # Gracefully stops the listener (completes active requests before shutting down).
+    #
+    # + return - Error? if graceful stop fails.
+    public isolated function gracefulStop() returns Error? => self.inner.gracefulStop();
+
+    # Immediately stops the listener (terminates all connections).
+    #
+    # + return - Error? if immediate stop fails.
+    public isolated function immediateStop() returns Error? => self.inner.immediateStop();
 }

--- a/ballerina/native_listener_helper.bal
+++ b/ballerina/native_listener_helper.bal
@@ -32,7 +32,8 @@ isolated function listToolsForRemoteFunctions(Service 'service, typedesc<ListToo
 } external;
 
 isolated function callToolForRemoteFunctions(Service 'service, CallToolParams params, Session? session,
-        http:Headers headers, typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
+        http:Headers headers, map<string[]> headerValues, boolean treatNilableAsOptional,
+        typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 

--- a/ballerina/native_listener_helper.bal
+++ b/ballerina/native_listener_helper.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/jballerina.java;
 
-isolated function invokeOnListTools(AdvancedService|StreamableHttpAdvancedService 'service)
+isolated function invokeOnListTools(AdvancedService 'service)
         returns ListToolsResult|Error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
@@ -27,8 +27,15 @@ isolated function invokeOnCallTool(AdvancedService 'service, CallToolParams para
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
-isolated function invokeOnCallToolWithRequest(StreamableHttpAdvancedService 'service, CallToolParams params,
-        Session? session, http:Request request) returns CallToolResult|Error = @java:Method {
+isolated function invokeAdvancedOnListTools(StreamableHttpAdvancedService 'service, http:Headers headers,
+        http:Request request, map<string[]> headerValues, boolean treatNilableAsOptional)
+        returns ListToolsResult|Error = @java:Method {
+    'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
+} external;
+
+isolated function invokeAdvancedOnCallTool(StreamableHttpAdvancedService 'service, CallToolParams params,
+        Session? session, http:Headers headers, http:Request request, map<string[]> headerValues,
+        boolean treatNilableAsOptional) returns CallToolResult|Error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 

--- a/ballerina/native_listener_helper.bal
+++ b/ballerina/native_listener_helper.bal
@@ -27,8 +27,8 @@ isolated function invokeOnCallTool(AdvancedService 'service, CallToolParams para
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
-isolated function invokeOnCallToolWithHeaders(StreamableHttpAdvancedService 'service, CallToolParams params,
-        Session? session, http:Headers headers) returns CallToolResult|Error = @java:Method {
+isolated function invokeOnCallToolWithRequest(StreamableHttpAdvancedService 'service, CallToolParams params,
+        Session? session, http:Request request) returns CallToolResult|Error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
@@ -38,8 +38,8 @@ isolated function listToolsForRemoteFunctions(Service|StreamableHttpService 'ser
 } external;
 
 isolated function callToolForRemoteFunctions(Service|StreamableHttpService 'service, CallToolParams params,
-        Session? session, http:Headers headers, map<string[]> headerValues, boolean treatNilableAsOptional,
-        typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
+        Session? session, http:Headers headers, http:Request request, map<string[]> headerValues,
+        boolean treatNilableAsOptional, typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 

--- a/ballerina/native_listener_helper.bal
+++ b/ballerina/native_listener_helper.bal
@@ -32,7 +32,7 @@ isolated function listToolsForRemoteFunctions(Service 'service, typedesc<ListToo
 } external;
 
 isolated function callToolForRemoteFunctions(Service 'service, CallToolParams params, Session? session,
-        typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
+        http:Headers headers, typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 

--- a/ballerina/native_listener_helper.bal
+++ b/ballerina/native_listener_helper.bal
@@ -17,7 +17,8 @@
 import ballerina/http;
 import ballerina/jballerina.java;
 
-isolated function invokeOnListTools(AdvancedService 'service) returns ListToolsResult|Error = @java:Method {
+isolated function invokeOnListTools(AdvancedService|StreamableHttpAdvancedService 'service)
+        returns ListToolsResult|Error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
@@ -26,23 +27,29 @@ isolated function invokeOnCallTool(AdvancedService 'service, CallToolParams para
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
-isolated function listToolsForRemoteFunctions(Service 'service, typedesc<ListToolsResult> t = <>)
-        returns t|Error = @java:Method {
+isolated function invokeOnCallToolWithHeaders(StreamableHttpAdvancedService 'service, CallToolParams params,
+        Session? session, http:Headers headers) returns CallToolResult|Error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
-isolated function callToolForRemoteFunctions(Service 'service, CallToolParams params, Session? session,
-        http:Headers headers, map<string[]> headerValues, boolean treatNilableAsOptional,
+isolated function listToolsForRemoteFunctions(Service|StreamableHttpService 'service,
+        typedesc<ListToolsResult> t = <>) returns t|Error = @java:Method {
+    'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
+} external;
+
+isolated function callToolForRemoteFunctions(Service|StreamableHttpService 'service, CallToolParams params,
+        Session? session, http:Headers headers, map<string[]> headerValues, boolean treatNilableAsOptional,
         typedesc<CallToolResult> t = <>) returns t|error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
-isolated function addMcpServiceToDispatcher(http:Service dispatcherService, Service|AdvancedService mcpService)
+isolated function addMcpServiceToDispatcher(http:Service dispatcherService,
+        Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService)
         returns Error? = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;
 
 isolated function getMcpServiceFromDispatcher(http:Service dispatcherService)
-        returns Service|AdvancedService|Error = @java:Method {
+        returns Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService|Error = @java:Method {
     'class: "io.ballerina.stdlib.mcp.McpServiceMethodHelper"
 } external;

--- a/ballerina/service_utils.bal
+++ b/ballerina/service_utils.bal
@@ -40,6 +40,22 @@ isolated function getSessionIdFromHeaders(http:Headers headers) returns string? 
     return sessionHeader is string ? sessionHeader : ();
 }
 
+# Extracts all header values into a map keyed by lower-cased header name,
+# used for binding `@mcp:Header` annotated tool parameters.
+#
+# + headers - HTTP headers of the request
+# + return - Map of header values keyed by lower-cased header name
+isolated function extractHeaderValues(http:Headers headers) returns map<string[]> {
+    map<string[]> headerValues = {};
+    foreach string headerName in headers.getHeaderNames() {
+        string[]|http:HeaderNotFoundError values = headers.getHeaders(headerName);
+        if values is string[] {
+            headerValues[headerName.toLowerAscii()] = values;
+        }
+    }
+    return headerValues;
+}
+
 # Determines the effective session mode based on configuration and request context.
 #
 # + config - Service configuration

--- a/ballerina/service_utils.bal
+++ b/ballerina/service_utils.bal
@@ -16,14 +16,38 @@
 
 import ballerina/http;
 
-# Retrieves the service configuration from an MCP service.
+# Resolves the effective Streamable HTTP configuration of an MCP service from its annotations.
 #
 # + mcpService - The MCP service instance
-# + return - The service configuration
-isolated function getServiceConfiguration(Service|AdvancedService mcpService) returns ServiceConfiguration {
+# + return - The resolved Streamable HTTP service configuration
+isolated function getServiceConfiguration(Service|AdvancedService|StreamableHttpService|StreamableHttpAdvancedService mcpService)
+        returns StreamableHttpServiceConfiguration {
     typedesc mcpServiceType = typeof mcpService;
+
+    // The transport-specific annotation is the configuration home for Streamable HTTP services.
+    StreamableHttpServiceConfiguration? transportConfig = mcpServiceType.@StreamableHttpServiceConfig;
+    if transportConfig is StreamableHttpServiceConfiguration {
+        return transportConfig;
+    }
+
+    // Fallback for transport-agnostic services. The deprecated httpConfig/sessionMode fields of
+    // @mcp:ServiceConfig are still honored here for backward compatibility (the only place the
+    // runtime reads these deprecated fields).
     ServiceConfiguration? serviceConfig = mcpServiceType.@ServiceConfig;
-    return serviceConfig ?: {
+    if serviceConfig is ServiceConfiguration {
+        StreamableHttpServiceConfiguration config = {
+            info: serviceConfig.info,
+            httpConfig: serviceConfig.httpConfig,
+            sessionMode: serviceConfig.sessionMode
+        };
+        ServerOptions? options = serviceConfig?.options;
+        if options is ServerOptions {
+            config.options = options;
+        }
+        return config;
+    }
+
+    return {
         info: {
             name: "MCP Service",
             version: "1.0.0"
@@ -62,7 +86,7 @@ isolated function extractHeaderValues(http:Headers headers) returns map<string[]
 # + headers - HTTP request headers
 # + requestMethod - The MCP request method (optional, used for AUTO mode logic)
 # + return - Effective session mode to use
-isolated function determineEffectiveSessionMode(ServiceConfiguration config, http:Headers headers, RequestMethod? requestMethod = ()) returns SessionMode {
+isolated function determineEffectiveSessionMode(StreamableHttpServiceConfiguration config, http:Headers headers, RequestMethod? requestMethod = ()) returns SessionMode {
     SessionMode configuredMode = config.sessionMode;
 
     if configuredMode == STATEFUL || configuredMode == STATELESS {

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -500,35 +500,29 @@ public type ToolExecution record {|
 |};
 
 # Definition for a tool the client can call.
+# A JSON Schema object describing the parameters or output of a tool.
+public type JsonSchema record {
+    # The JSON Schema version
+    string \$schema?;
+    # The type of the schema
+    "object" 'type;
+    # The properties of the schema
+    map<anydata> properties?;
+    # The required properties of the schema
+    string[] required?;
+};
+
 public type ToolDefinition record {
     *BaseMetadata;
     *Icons;
     # A human-readable description of the tool.
     string description?;
     # A JSON Schema object defining the expected parameters for the tool.
-    record {
-        # The JSON Schema version
-        string \$schema?;
-        # The type of the schema
-        "object" 'type;
-        # The properties of the schema
-        map<anydata> properties?;
-        # The required properties of the schema
-        string[] required?;
-    } inputSchema;
+    JsonSchema inputSchema;
     # Execution-related properties for this tool.
     ToolExecution execution?;
     # An optional JSON Schema object defining the structure of the tool's output.
-    record {
-        # The JSON Schema version
-        string \$schema?;
-        # The type of the schema
-        "object" 'type;
-        # The properties of the schema
-        map<anydata> properties?;
-        # The required properties of the schema
-        string[] required?;
-    } outputSchema?;
+    JsonSchema outputSchema?;
     # Optional additional tool information.
     ToolAnnotations annotations?;
 };

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -503,7 +503,7 @@ public type AdvancedService distinct service object {
     remote isolated function onListTools() returns ListToolsResult|ServerError;
     remote isolated function onCallTool(CallToolParams params, Session? session = ()) returns CallToolResult|ServerError;
 };
-
+ 
 # Defines a transport-agnostic basic MCP service interface. Tools are declared as `remote`
 # functions and cannot access transport-specific request information.
 public type Service distinct service object {
@@ -518,10 +518,10 @@ public type StreamableHttpService distinct service object {
 };
 
 # Defines an MCP service interface exposed over the Streamable HTTP transport with manual control
-# over tool listing and invocation. `onCallTool` additionally receives the underlying `http:Request`,
-# from which headers and other transport-specific request information can be accessed.
+# over tool listing and invocation. The service must declare `onListTools` and `onCallTool` `remote`
+# methods. In addition to `mcp:CallToolParams` and an optional `mcp:Session`, these methods may bind
+# transport-specific request information the same way `mcp:StreamableHttpService` tools can — via
+# `@http:Header` parameters, an `http:Headers` parameter, and/or an `http:Request` parameter. The
+# compiler plugin validates the shape of these methods.
 public type StreamableHttpAdvancedService distinct service object {
-    remote isolated function onListTools() returns ListToolsResult|ServerError;
-    remote isolated function onCallTool(CallToolParams params, Session? session, http:Request request)
-        returns CallToolResult|ServerError;
 };

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -451,14 +451,42 @@ public type ServerOptions record {|
     boolean enforceStrictCapabilities?;
 |};
 
-# Configuration for MCP service that defines server capabilities, metadata, and transport options.
+# Transport-agnostic configuration for an MCP service, defining server metadata and options.
 public type ServiceConfiguration record {|
-    # HTTP service configuration for the underlying transport
-    http:HttpServiceConfig httpConfig = {};
     # Server implementation information
     Implementation info;
     # Optional server configuration options
     ServerOptions options?;
+    # HTTP service configuration for the underlying transport.
+    #
+    # # Deprecated
+    # HTTP configuration is transport-specific. Use the `httpConfig` field of the
+    # `@mcp:StreamableHttpServiceConfig` annotation on an `mcp:StreamableHttpService` instead.
+    @deprecated
+    http:HttpServiceConfig httpConfig = {};
+    # Controls the session management mode for the transport.
+    # - STATEFUL → Sessions are managed by the transport with session IDs
+    # - STATELESS → No session management, each request is independent
+    # - AUTO → Automatically determined based on client initialization behavior (default)
+    #
+    # # Deprecated
+    # Session management is transport-specific. Use the `sessionMode` field of the
+    # `@mcp:StreamableHttpServiceConfig` annotation on an `mcp:StreamableHttpService` instead.
+    @deprecated
+    SessionMode sessionMode = AUTO;
+|};
+
+# Annotation to provide configuration to MCP services.
+public annotation ServiceConfiguration ServiceConfig on service;
+
+# Configuration for an MCP service exposed over the Streamable HTTP transport.
+public type StreamableHttpServiceConfiguration record {|
+    # Server implementation information
+    Implementation info;
+    # Optional server configuration options
+    ServerOptions options?;
+    # HTTP service configuration for the underlying transport
+    http:HttpServiceConfig httpConfig = {};
     # Controls the session management mode for the transport.
     # - STATEFUL → Sessions are managed by the transport with session IDs
     # - STATELESS → No session management, each request is independent
@@ -466,16 +494,33 @@ public type ServiceConfiguration record {|
     SessionMode sessionMode = AUTO;
 |};
 
-# Annotation to provide service configuration to MCP services.
-public annotation ServiceConfiguration ServiceConfig on service;
+# Annotation to provide configuration to Streamable HTTP MCP services.
+public annotation StreamableHttpServiceConfiguration StreamableHttpServiceConfig on service;
 
-# Defines an MCP service interface that handles incoming MCP requests.
+# Defines a transport-agnostic MCP service interface that handles incoming MCP requests with
+# manual control over tool listing and invocation.
 public type AdvancedService distinct service object {
     remote isolated function onListTools() returns ListToolsResult|ServerError;
     remote isolated function onCallTool(CallToolParams params, Session? session = ()) returns CallToolResult|ServerError;
 };
 
-# Defines a basic mcp service interface that handles incoming mcp requests.
+# Defines a transport-agnostic basic MCP service interface. Tools are declared as `remote`
+# functions and cannot access transport-specific request information.
 public type Service distinct service object {
 
+};
+
+# Defines a basic MCP service interface exposed over the Streamable HTTP transport. Tool
+# `remote` functions may additionally bind HTTP request information (e.g. `@http:Header`
+# parameters or an `http:Headers` parameter).
+public type StreamableHttpService distinct service object {
+
+};
+
+# Defines an MCP service interface exposed over the Streamable HTTP transport with manual control
+# over tool listing and invocation. `onCallTool` additionally receives the request's `http:Headers`.
+public type StreamableHttpAdvancedService distinct service object {
+    remote isolated function onListTools() returns ListToolsResult|ServerError;
+    remote isolated function onCallTool(CallToolParams params, Session? session, http:Headers headers)
+        returns CallToolResult|ServerError;
 };

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -512,15 +512,16 @@ public type Service distinct service object {
 
 # Defines a basic MCP service interface exposed over the Streamable HTTP transport. Tool
 # `remote` functions may additionally bind HTTP request information (e.g. `@http:Header`
-# parameters or an `http:Headers` parameter).
+# parameters, an `http:Headers` parameter, or an `http:Request` parameter).
 public type StreamableHttpService distinct service object {
 
 };
 
 # Defines an MCP service interface exposed over the Streamable HTTP transport with manual control
-# over tool listing and invocation. `onCallTool` additionally receives the request's `http:Headers`.
+# over tool listing and invocation. `onCallTool` additionally receives the underlying `http:Request`,
+# from which headers and other transport-specific request information can be accessed.
 public type StreamableHttpAdvancedService distinct service object {
     remote isolated function onListTools() returns ListToolsResult|ServerError;
-    remote isolated function onCallTool(CallToolParams params, Session? session, http:Headers headers)
+    remote isolated function onCallTool(CallToolParams params, Session? session, http:Request request)
         returns CallToolResult|ServerError;
 };

--- a/build.gradle
+++ b/build.gradle
@@ -115,5 +115,6 @@ release {
 task build {
     dependsOn(':mcp-ballerina:build')
     dependsOn(':mcp-native:build')
+    dependsOn(':mcp-compiler-plugin-tests:test')
     dependsOn(':mcp-ballerina-tests:test')
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+}
+
+description = 'Ballerina - MCP Compiler Plugin Tests'
+
+dependencies {
+    implementation project(':mcp-compiler-plugin')
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+
+compileTestJava {
+    dependsOn ':mcp-compiler-plugin:copyOpenApiJar'
+}
+
+test {
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+        exceptionFormat = "full"
+        showStandardStreams = true
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Compiler Plugin Tests: ${result.resultType} (${result.testCount} tests, " +
+                        "${result.successfulTestCount} successes, ${result.failedTestCount} failures, " +
+                        "${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+    dependsOn ':mcp-ballerina:build'
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mcp.plugin;
+
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests for the MCP compiler plugin diagnostics on '@http:Header' and 'http:Headers'
+ * tool parameters.
+ */
+public class CompilerPluginTest {
+
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "ballerina_sources")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
+            .toAbsolutePath();
+
+    private static final String MCP_105 = "MCP_105";
+    private static final String MCP_106 = "MCP_106";
+
+    private Package loadPackage(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
+        return project.currentPackage();
+    }
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private DiagnosticResult compile(String path) {
+        Package currentPackage = loadPackage(path);
+        // The MCP compiler plugin is registered as a CodeModifier, so its diagnostics are
+        // reported by the code-generate/modify phase, not by getCompilation() alone
+        return currentPackage.runCodeGenAndModifyPlugins();
+    }
+
+    private long errorCount(DiagnosticResult diagnosticResult) {
+        return diagnosticResult.diagnostics().stream()
+                .filter(d -> d.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
+    }
+
+    private void assertError(DiagnosticResult diagnosticResult, int index, String messagePart, String code) {
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[index];
+        Assert.assertTrue(diagnostic.message().contains(messagePart),
+                "expected message containing '" + messagePart + "' but found: " + diagnostic.message());
+        Assert.assertEquals(diagnostic.diagnosticInfo().code(), code);
+    }
+
+    @Test
+    public void testValidHeaderParameterTypes() {
+        DiagnosticResult diagnosticResult = compile("sample_package_1");
+        Assert.assertEquals(errorCount(diagnosticResult), 0,
+                "valid header parameter shapes must not produce errors: "
+                        + diagnosticResult.errors().toString());
+    }
+
+    @Test
+    public void testInvalidUnionHeaderParamType() {
+        DiagnosticResult diagnosticResult = compile("sample_package_2");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Invalid type of header param 'mixed'", MCP_106);
+    }
+
+    @Test
+    public void testHeaderRecordWithRestFields() {
+        DiagnosticResult diagnosticResult = compile("sample_package_3");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Invalid type of header param 'hdrs'", MCP_106);
+    }
+
+    @Test
+    public void testDuplicateHttpHeadersParams() {
+        DiagnosticResult diagnosticResult = compile("sample_package_4");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Duplicate headers parameter 'second'", MCP_105);
+    }
+
+    @Test
+    public void testInvalidHeaderParamType() {
+        DiagnosticResult diagnosticResult = compile("sample_package_5");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Invalid type of header param 'payload'", MCP_106);
+    }
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -44,13 +44,13 @@ public class CompilerPluginTest {
 
     private static final String MCP_102 = "MCP_102";
     private static final String MCP_104 = "MCP_104";
-    private static final String MCP_105 = "MCP_105";
-    private static final String MCP_106 = "MCP_106";
     private static final String MCP_107 = "MCP_107";
     private static final String MCP_108 = "MCP_108";
     private static final String MCP_109 = "MCP_109";
     private static final String MCP_110 = "MCP_110";
     private static final String MCP_111 = "MCP_111";
+    private static final String MCP_112 = "MCP_112";
+    private static final String MCP_113 = "MCP_113";
 
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
@@ -94,36 +94,36 @@ public class CompilerPluginTest {
     public void testInvalidUnionHeaderParamType() {
         DiagnosticResult diagnosticResult = compile("sample_package_2");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Invalid type of header param 'mixed'", MCP_106);
+        assertError(diagnosticResult, 0, "Invalid type of header param 'mixed'", MCP_108);
     }
 
     @Test
     public void testHeaderRecordWithRestFields() {
         DiagnosticResult diagnosticResult = compile("sample_package_3");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Invalid type of header param 'hdrs'", MCP_106);
+        assertError(diagnosticResult, 0, "Invalid type of header param 'hdrs'", MCP_108);
     }
 
     @Test
     public void testDuplicateHttpHeadersParams() {
         DiagnosticResult diagnosticResult = compile("sample_package_4");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_105);
-        assertError(diagnosticResult, 0, "type 'http:Headers'", MCP_105);
+        assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_107);
+        assertError(diagnosticResult, 0, "type 'http:Headers'", MCP_107);
     }
 
     @Test
     public void testInvalidHeaderParamType() {
         DiagnosticResult diagnosticResult = compile("sample_package_5");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Invalid type of header param 'payload'", MCP_106);
+        assertError(diagnosticResult, 0, "Invalid type of header param 'payload'", MCP_108);
     }
 
     @Test
     public void testHeaderParamRequiresStreamableHttpService() {
         DiagnosticResult diagnosticResult = compile("sample_package_6");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
+        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_109);
     }
 
     @Test
@@ -137,22 +137,22 @@ public class CompilerPluginTest {
     public void testRawHeadersParamRequiresStreamableHttpService() {
         DiagnosticResult diagnosticResult = compile("sample_package_8");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
+        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_109);
     }
 
     @Test
     public void testRequestParamRequiresStreamableHttpService() {
         DiagnosticResult diagnosticResult = compile("sample_package_9");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
+        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_109);
     }
 
     @Test
     public void testDuplicateHttpRequestParams() {
         DiagnosticResult diagnosticResult = compile("sample_package_10");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_105);
-        assertError(diagnosticResult, 0, "type 'http:Request'", MCP_105);
+        assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_107);
+        assertError(diagnosticResult, 0, "type 'http:Request'", MCP_107);
     }
 
     @Test
@@ -167,14 +167,14 @@ public class CompilerPluginTest {
     public void testAdvancedServiceMissingOnCallTool() {
         DiagnosticResult diagnosticResult = compile("sample_package_12");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "must define a remote method 'onCallTool'", MCP_108);
+        assertError(diagnosticResult, 0, "must define a remote method 'onCallTool'", MCP_110);
     }
 
     @Test
     public void testAdvancedOnCallToolMissingCallToolParams() {
         DiagnosticResult diagnosticResult = compile("sample_package_13");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "must declare exactly one parameter of type mcp:CallToolParams", MCP_109);
+        assertError(diagnosticResult, 0, "must declare exactly one parameter of type mcp:CallToolParams", MCP_111);
     }
 
     @Test
@@ -189,13 +189,13 @@ public class CompilerPluginTest {
     public void testAdvancedInvalidReturnType() {
         DiagnosticResult diagnosticResult = compile("sample_package_15");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "must return 'mcp:CallToolResult|mcp:ServerError'", MCP_110);
+        assertError(diagnosticResult, 0, "must return 'mcp:CallToolResult|mcp:ServerError'", MCP_112);
     }
 
     @Test
     public void testAdvancedUnknownRemoteMethod() {
         DiagnosticResult diagnosticResult = compile("sample_package_16");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Remote method 'doSomething' is not supported", MCP_111);
+        assertError(diagnosticResult, 0, "Remote method 'doSomething' is not supported", MCP_113);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -103,7 +103,8 @@ public class CompilerPluginTest {
     public void testDuplicateHttpHeadersParams() {
         DiagnosticResult diagnosticResult = compile("sample_package_4");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
-        assertError(diagnosticResult, 0, "Duplicate headers parameter 'second'", MCP_105);
+        assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_105);
+        assertError(diagnosticResult, 0, "type 'http:Headers'", MCP_105);
     }
 
     @Test
@@ -132,5 +133,20 @@ public class CompilerPluginTest {
         DiagnosticResult diagnosticResult = compile("sample_package_8");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
         assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
+    }
+
+    @Test
+    public void testRequestParamRequiresStreamableHttpService() {
+        DiagnosticResult diagnosticResult = compile("sample_package_9");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
+    }
+
+    @Test
+    public void testDuplicateHttpRequestParams() {
+        DiagnosticResult diagnosticResult = compile("sample_package_10");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_105);
+        assertError(diagnosticResult, 0, "type 'http:Request'", MCP_105);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -33,8 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 /**
- * Tests for the MCP compiler plugin diagnostics on '@http:Header' and 'http:Headers'
- * tool parameters.
+ * Tests for the MCP compiler plugin diagnostics on '@http:Header' and 'http:Headers' tool parameters.
  */
 public class CompilerPluginTest {
 
@@ -43,8 +42,10 @@ public class CompilerPluginTest {
     private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
             .toAbsolutePath();
 
+    private static final String MCP_104 = "MCP_104";
     private static final String MCP_105 = "MCP_105";
     private static final String MCP_106 = "MCP_106";
+    private static final String MCP_107 = "MCP_107";
 
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
@@ -110,5 +111,26 @@ public class CompilerPluginTest {
         DiagnosticResult diagnosticResult = compile("sample_package_5");
         Assert.assertEquals(errorCount(diagnosticResult), 1);
         assertError(diagnosticResult, 0, "Invalid type of header param 'payload'", MCP_106);
+    }
+
+    @Test
+    public void testHeaderParamRequiresStreamableHttpService() {
+        DiagnosticResult diagnosticResult = compile("sample_package_6");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
+    }
+
+    @Test
+    public void testSessionParamStatelessViaTransportConfig() {
+        DiagnosticResult diagnosticResult = compile("sample_package_7");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "is not allowed when sessionMode is STATELESS", MCP_104);
+    }
+
+    @Test
+    public void testRawHeadersParamRequiresStreamableHttpService() {
+        DiagnosticResult diagnosticResult = compile("sample_package_8");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "accesses transport-specific properties", MCP_107);
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -198,4 +198,18 @@ public class CompilerPluginTest {
         Assert.assertEquals(errorCount(diagnosticResult), 1);
         assertError(diagnosticResult, 0, "Remote method 'doSomething' is not supported", MCP_113);
     }
+
+    @Test
+    public void testAdvancedListToolsUnsupportedParam() {
+        DiagnosticResult diagnosticResult = compile("sample_package_17");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0,
+                "Parameter 'params' in function 'onListTools' has an unsupported type", MCP_102);
+        // The supported-types message for 'onListTools' must not advertise the 'onCallTool'-only types.
+        Diagnostic diagnostic = (Diagnostic) diagnosticResult.errors().toArray()[0];
+        Assert.assertFalse(diagnostic.message().contains("mcp:CallToolParams"),
+                "onListTools supported-types message must not list 'mcp:CallToolParams': " + diagnostic.message());
+        Assert.assertFalse(diagnostic.message().contains("mcp:Session"),
+                "onListTools supported-types message must not list 'mcp:Session': " + diagnostic.message());
+    }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -42,10 +42,15 @@ public class CompilerPluginTest {
     private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
             .toAbsolutePath();
 
+    private static final String MCP_102 = "MCP_102";
     private static final String MCP_104 = "MCP_104";
     private static final String MCP_105 = "MCP_105";
     private static final String MCP_106 = "MCP_106";
     private static final String MCP_107 = "MCP_107";
+    private static final String MCP_108 = "MCP_108";
+    private static final String MCP_109 = "MCP_109";
+    private static final String MCP_110 = "MCP_110";
+    private static final String MCP_111 = "MCP_111";
 
     private Package loadPackage(String path) {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
@@ -148,5 +153,49 @@ public class CompilerPluginTest {
         Assert.assertEquals(errorCount(diagnosticResult), 1);
         assertError(diagnosticResult, 0, "Duplicate parameter 'second'", MCP_105);
         assertError(diagnosticResult, 0, "type 'http:Request'", MCP_105);
+    }
+
+    @Test
+    public void testValidAdvancedService() {
+        DiagnosticResult diagnosticResult = compile("sample_package_11");
+        Assert.assertEquals(errorCount(diagnosticResult), 0,
+                "valid advanced service shapes must not produce errors: "
+                        + diagnosticResult.errors().toString());
+    }
+
+    @Test
+    public void testAdvancedServiceMissingOnCallTool() {
+        DiagnosticResult diagnosticResult = compile("sample_package_12");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "must define a remote method 'onCallTool'", MCP_108);
+    }
+
+    @Test
+    public void testAdvancedOnCallToolMissingCallToolParams() {
+        DiagnosticResult diagnosticResult = compile("sample_package_13");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "must declare exactly one parameter of type mcp:CallToolParams", MCP_109);
+    }
+
+    @Test
+    public void testAdvancedUnsupportedParam() {
+        DiagnosticResult diagnosticResult = compile("sample_package_14");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Parameter 'extra' in function 'onCallTool' has an unsupported type",
+                MCP_102);
+    }
+
+    @Test
+    public void testAdvancedInvalidReturnType() {
+        DiagnosticResult diagnosticResult = compile("sample_package_15");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "must return 'mcp:CallToolResult|mcp:ServerError'", MCP_110);
+    }
+
+    @Test
+    public void testAdvancedUnknownRemoteMethod() {
+        DiagnosticResult diagnosticResult = compile("sample_package_16");
+        Assert.assertEquals(errorCount(diagnosticResult), 1);
+        assertError(diagnosticResult, 0, "Remote method 'doSomething' is not supported", MCP_111);
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_1"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
@@ -29,11 +29,12 @@ type CallerHeaders record {|
     string[] accept?;
 |};
 
-// Every supported @http:Header parameter shape must compile without diagnostics.
-@mcp:ServiceConfig {
+// Every supported @http:Header parameter shape must compile without diagnostics on an
+// mcp:StreamableHttpService.
+@mcp:StreamableHttpServiceConfig {
     info: {name: "sample-1", version: "1.0.0"}
 }
-service mcp:Service /mcp on new mcp:Listener(9301) {
+service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9301) {
 
     @mcp:Tool {description: "single header bound by parameter name"}
     remote function tString(@http:Header string authorization, string name) returns string {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
@@ -72,4 +72,9 @@ service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9301) {
     remote function tRecord(@http:Header CallerHeaders hdrs, http:Headers rawHeaders) returns string {
         return hdrs.authorization;
     }
+
+    @mcp:Tool {description: "raw request object alongside a tool argument"}
+    remote function tRequest(http:Request request, string name) returns string {
+        return name;
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_1/service.bal
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+enum ApiVersion {
+    V1 = "v1",
+    V2 = "v2"
+}
+
+type CallerHeaders record {|
+    string authorization;
+    @http:Header {name: "X-Tenant-Id"}
+    string tenantId?;
+    string[] accept?;
+|};
+
+// Every supported @http:Header parameter shape must compile without diagnostics.
+@mcp:ServiceConfig {
+    info: {name: "sample-1", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:Listener(9301) {
+
+    @mcp:Tool {description: "single header bound by parameter name"}
+    remote function tString(@http:Header string authorization, string name) returns string {
+        return name + authorization;
+    }
+
+    @mcp:Tool {description: "named nilable header"}
+    remote function tNamedNilable(@http:Header {name: "X-Tenant-Id"} string? tenant) returns string {
+        return tenant ?: "<none>";
+    }
+
+    @mcp:Tool {description: "basic typed headers and arrays"}
+    remote function tTyped(@http:Header {name: "X-Retry-Count"} int retries,
+            @http:Header {name: "X-Debug"} boolean debug,
+            @http:Header {name: "X-Rate"} decimal? rate,
+            @http:Header {name: "X-Factor"} float factor,
+            @http:Header {name: "X-Shard"} int[]? shards) returns string {
+        return string `${retries}:${debug}:${rate ?: 0d}:${factor}:${(shards ?: []).length()}`;
+    }
+
+    @mcp:Tool {description: "enum and finite string headers"}
+    remote function tFinite(@http:Header {name: "X-Ver"} ApiVersion ver,
+            @http:Header {name: "X-Ver2"} ApiVersion? maybeVer,
+            @http:Header {name: "X-Mode"} "fast"|"slow" mode) returns string {
+        return string `${ver}:${maybeVer ?: ""}:${mode}`;
+    }
+
+    @mcp:Tool {description: "readonly intersection headers"}
+    remote function tReadonly(@http:Header {name: "X-Tag"} readonly & string[] tags,
+            @http:Header readonly & CallerHeaders hdrs) returns string {
+        return hdrs.authorization + tags.length().toString();
+    }
+
+    @mcp:Tool {description: "record binding alongside the raw headers object"}
+    remote function tRecord(@http:Header CallerHeaders hdrs, http:Headers rawHeaders) returns string {
+        return hdrs.authorization;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_10"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// Only a single http:Request parameter is allowed per tool (MCP_108).
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-10", version: "1.0.0"}
+}
+service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9310) {
+
+    @mcp:Tool {description: "duplicate request parameters"}
+    remote function dupRequest(http:Request first, http:Request second) returns string {
+        return "ok";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_10/service.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/mcp;
 
-// Only a single http:Request parameter is allowed per tool (MCP_108).
+// Only a single http:Request parameter is allowed per tool (MCP_107).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-10", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_11/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_11/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_11"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_11/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_11/service.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// An mcp:StreamableHttpAdvancedService whose remote methods bind transport-specific request
+// information the same way StreamableHttpService tools do. Must compile without diagnostics.
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-11", version: "1.0.0"}
+}
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9311) {
+
+    remote function onListTools(@http:Header {name: "X-Filter"} string? filter, http:Headers headers)
+            returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+
+    remote function onCallTool(mcp:CallToolParams params, mcp:Session? session,
+            @http:Header {name: "Authorization"} string? auth, http:Headers headers, http:Request request)
+            returns mcp:CallToolResult|mcp:ServerError {
+        return {content: []};
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_12"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/service.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+
+// Missing the required onCallTool remote method (MCP_108).
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-12", version: "1.0.0"}
+}
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9312) {
+
+    remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_12/service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/mcp;
 
-// Missing the required onCallTool remote method (MCP_108).
+// Missing the required onCallTool remote method (MCP_110).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-12", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_13/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_13/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_13"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_13/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_13/service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/mcp;
 
-// onCallTool does not declare a CallToolParams parameter (MCP_109).
+// onCallTool does not declare a CallToolParams parameter (MCP_111).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-13", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_13/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_13/service.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+
+// onCallTool does not declare a CallToolParams parameter (MCP_109).
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-13", version: "1.0.0"}
+}
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9313) {
+
+    remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+
+    remote function onCallTool(mcp:Session? session) returns mcp:CallToolResult|mcp:ServerError {
+        return {content: []};
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_14/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_14/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_14"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_14/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_14/service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/mcp;
 
-// onCallTool declares an unsupported plain parameter (MCP_110).
+// onCallTool declares an unsupported plain parameter (MCP_102).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-14", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_14/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_14/service.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+
+// onCallTool declares an unsupported plain parameter (MCP_110).
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-14", version: "1.0.0"}
+}
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9314) {
+
+    remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+
+    remote function onCallTool(mcp:CallToolParams params, string extra)
+            returns mcp:CallToolResult|mcp:ServerError {
+        return {content: []};
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_15"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+
+// onCallTool returns the wrong type (MCP_111).
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-15", version: "1.0.0"}
+}
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9315) {
+
+    remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+
+    remote function onCallTool(mcp:CallToolParams params) returns string {
+        return "x";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_15/service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/mcp;
 
-// onCallTool returns the wrong type (MCP_111).
+// onCallTool returns the wrong type (MCP_112).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-15", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_16/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_16/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_16"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_16/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_16/service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/mcp;
 
-// Only onListTools and onCallTool are allowed; any other remote method is unsupported (MCP_111).
+// Only onListTools and onCallTool are allowed; any other remote method is unsupported (MCP_113).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-16", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_16/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_16/service.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+
+// Only onListTools and onCallTool are allowed; any other remote method is unsupported (MCP_111).
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "sample-16", version: "1.0.0"}
+}
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9316) {
+
+    remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+
+    remote function onCallTool(mcp:CallToolParams params) returns mcp:CallToolResult|mcp:ServerError {
+        return {content: []};
+    }
+
+    remote function doSomething() returns string {
+        return "unsupported";
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_17/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_17/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_17"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_17/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_17/service.bal
@@ -14,17 +14,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
 import ballerina/mcp;
 
-// Header parameters must be string/int/float/decimal/boolean based (MCP_108).
+// onListTools does not accept mcp:CallToolParams or mcp:Session; the reported supported types
+// must be specific to onListTools and must not list those two (MCP_102).
 @mcp:StreamableHttpServiceConfig {
-    info: {name: "sample-5", version: "1.0.0"}
+    info: {name: "sample-17", version: "1.0.0"}
 }
-service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9305) {
+service mcp:StreamableHttpAdvancedService /mcp on new mcp:StreamableHttpListener(9317) {
 
-    @mcp:Tool {description: "xml is not a valid header param type"}
-    remote function badXml(@http:Header xml payload) returns string {
-        return payload.toString();
+    remote function onListTools(mcp:CallToolParams params) returns mcp:ListToolsResult|mcp:ServerError {
+        return {tools: []};
+    }
+
+    remote function onCallTool(mcp:CallToolParams params) returns mcp:CallToolResult|mcp:ServerError {
+        return {content: []};
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_2"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/mcp;
 
-// A union of two distinct basic types is not a valid header parameter type (MCP_106).
+// A union of two distinct basic types is not a valid header parameter type (MCP_108).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-2", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// A union of two distinct basic types is not a valid header parameter type (MCP_106).
+@mcp:ServiceConfig {
+    info: {name: "sample-2", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:Listener(9302) {
+
+    @mcp:Tool {description: "invalid union header type"}
+    remote function badUnion(@http:Header string|int mixed) returns string {
+        return mixed.toString();
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_2/service.bal
@@ -18,10 +18,10 @@ import ballerina/http;
 import ballerina/mcp;
 
 // A union of two distinct basic types is not a valid header parameter type (MCP_106).
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {name: "sample-2", version: "1.0.0"}
 }
-service mcp:Service /mcp on new mcp:Listener(9302) {
+service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9302) {
 
     @mcp:Tool {description: "invalid union header type"}
     remote function badUnion(@http:Header string|int mixed) returns string {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_3"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// Header binding records must not have rest fields (MCP_106).
+type OpenHeaders record {|
+    string authorization;
+    string...;
+|};
+
+@mcp:ServiceConfig {
+    info: {name: "sample-3", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:Listener(9303) {
+
+    @mcp:Tool {description: "header record with rest field"}
+    remote function badRecord(@http:Header OpenHeaders hdrs) returns string {
+        return hdrs.authorization;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_3/service.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/mcp;
 
-// Header binding records must not have rest fields (MCP_106).
+// Header binding records must not have rest fields (MCP_108).
 type OpenHeaders record {|
     string authorization;
     string...;

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_4"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// Only one parameter of type http:Headers is allowed per tool (MCP_105).
+@mcp:ServiceConfig {
+    info: {name: "sample-4", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:Listener(9304) {
+
+    @mcp:Tool {description: "duplicate http:Headers parameters"}
+    remote function badHeaders(http:Headers first, http:Headers second, string name) returns string {
+        return name;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
@@ -18,10 +18,10 @@ import ballerina/http;
 import ballerina/mcp;
 
 // Only one parameter of type http:Headers is allowed per tool (MCP_105).
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {name: "sample-4", version: "1.0.0"}
 }
-service mcp:Service /mcp on new mcp:Listener(9304) {
+service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9304) {
 
     @mcp:Tool {description: "duplicate http:Headers parameters"}
     remote function badHeaders(http:Headers first, http:Headers second, string name) returns string {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_4/service.bal
@@ -17,7 +17,7 @@
 import ballerina/http;
 import ballerina/mcp;
 
-// Only one parameter of type http:Headers is allowed per tool (MCP_105).
+// Only one parameter of type http:Headers is allowed per tool (MCP_107).
 @mcp:StreamableHttpServiceConfig {
     info: {name: "sample-4", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_5"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// Header parameters must be string/int/float/decimal/boolean based (MCP_106).
+@mcp:ServiceConfig {
+    info: {name: "sample-5", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:Listener(9305) {
+
+    @mcp:Tool {description: "xml is not a valid header param type"}
+    remote function badXml(@http:Header xml payload) returns string {
+        return payload.toString();
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_5/service.bal
@@ -18,10 +18,10 @@ import ballerina/http;
 import ballerina/mcp;
 
 // Header parameters must be string/int/float/decimal/boolean based (MCP_106).
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {name: "sample-5", version: "1.0.0"}
 }
-service mcp:Service /mcp on new mcp:Listener(9305) {
+service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9305) {
 
     @mcp:Tool {description: "xml is not a valid header param type"}
     remote function badXml(@http:Header xml payload) returns string {

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_6"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/service.bal
@@ -17,7 +17,7 @@ import ballerina/http;
 import ballerina/mcp;
 
 // A @http:Header parameter is a transport-specific property and is not accessible in the
-// transport-agnostic mcp:Service (MCP_107).
+// transport-agnostic mcp:Service (MCP_109).
 @mcp:ServiceConfig {
     info: {name: "sample-6", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_6/service.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the specific language governing permissions and
+// limitations under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// A @http:Header parameter is a transport-specific property and is not accessible in the
+// transport-agnostic mcp:Service (MCP_107).
+@mcp:ServiceConfig {
+    info: {name: "sample-6", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:StreamableHttpListener(9306) {
+
+    @mcp:Tool {description: "header binding on the transport-agnostic service"}
+    remote function badHeader(@http:Header string authorization, string name) returns string {
+        return name + authorization;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_7"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_7/service.bal
@@ -14,22 +14,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
 import ballerina/mcp;
 
-// Header binding records must not have rest fields (MCP_106).
-type OpenHeaders record {|
-    string authorization;
-    string...;
-|};
-
+// sessionMode declared via the transport-specific @mcp:StreamableHttpServiceConfig annotation
+// must be honored by the plugin: a Session parameter under STATELESS is an error (MCP_104).
 @mcp:StreamableHttpServiceConfig {
-    info: {name: "sample-3", version: "1.0.0"}
+    info: {name: "sample-7", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
 }
-service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9303) {
+service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9307) {
 
-    @mcp:Tool {description: "header record with rest field"}
-    remote function badRecord(@http:Header OpenHeaders hdrs) returns string {
-        return hdrs.authorization;
+    @mcp:Tool {description: "session param under stateless transport config"}
+    remote function badSession(mcp:Session session, string name) returns string {
+        return name;
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_8"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -17,19 +17,15 @@
 import ballerina/http;
 import ballerina/mcp;
 
-// Header binding records must not have rest fields (MCP_106).
-type OpenHeaders record {|
-    string authorization;
-    string...;
-|};
-
-@mcp:StreamableHttpServiceConfig {
-    info: {name: "sample-3", version: "1.0.0"}
+// A raw http:Headers parameter is a transport-specific property and is not accessible in the
+// transport-agnostic mcp:Service (MCP_107).
+@mcp:ServiceConfig {
+    info: {name: "sample-8", version: "1.0.0"}
 }
-service mcp:StreamableHttpService /mcp on new mcp:StreamableHttpListener(9303) {
+service mcp:Service /mcp on new mcp:StreamableHttpListener(9308) {
 
-    @mcp:Tool {description: "header record with rest field"}
-    remote function badRecord(@http:Header OpenHeaders hdrs) returns string {
-        return hdrs.authorization;
+    @mcp:Tool {description: "raw headers object on the transport-agnostic service"}
+    remote function badRaw(http:Headers headers, string name) returns string {
+        return name;
     }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_8/service.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/mcp;
 
 // A raw http:Headers parameter is a transport-specific property and is not accessible in the
-// transport-agnostic mcp:Service (MCP_107).
+// transport-agnostic mcp:Service (MCP_109).
 @mcp:ServiceConfig {
     info: {name: "sample-8", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_9/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_9/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_9"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_9/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_9/service.bal
@@ -18,7 +18,7 @@ import ballerina/http;
 import ballerina/mcp;
 
 // A raw http:Request parameter is a transport-specific property and is not accessible in the
-// transport-agnostic mcp:Service (MCP_107).
+// transport-agnostic mcp:Service (MCP_109).
 @mcp:ServiceConfig {
     info: {name: "sample-9", version: "1.0.0"}
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_9/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_9/service.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/mcp;
+
+// A raw http:Request parameter is a transport-specific property and is not accessible in the
+// transport-agnostic mcp:Service (MCP_107).
+@mcp:ServiceConfig {
+    info: {name: "sample-9", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:StreamableHttpListener(9309) {
+
+    @mcp:Tool {description: "raw request object on the transport-agnostic service"}
+    remote function badRequest(http:Request request, string name) returns string {
+        return name;
+    }
+}

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="McpCompilerPluginTestSuite">
+    <test name="mcp-compiler-plugin-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="io.ballerina.stdlib.mcp.plugin.CompilerPluginTest"/>
+        </classes>
+    </test>
+</suite>

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/AdvancedServiceAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/AdvancedServiceAnalysisTask.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.mcp.plugin;
+
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.mcp.plugin.diagnostics.CompilationDiagnostic;
+import io.ballerina.tools.diagnostics.Location;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Analysis task that validates the remote methods of an {@code mcp:StreamableHttpAdvancedService}.
+ *
+ * <p>The service type is an empty marker, so this task enforces the contract the type used to pin: the service
+ * must declare {@code onListTools} and {@code onCallTool} remote methods, and their parameters are restricted to the
+ * supported set (CallToolParams, Session, http:Headers, http:Request, and {@code @http:Header} parameters).</p>
+ */
+public class AdvancedServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnalysisContext> {
+
+    private static final String ON_CALL_TOOL = "onCallTool";
+    private static final String ON_LIST_TOOLS = "onListTools";
+    private static final String HTTP_HEADERS_DISPLAY = "http:Headers";
+    private static final String HTTP_REQUEST_DISPLAY = "http:Request";
+    private static final String SESSION_DISPLAY = "mcp:Session";
+    private static final String CALL_TOOL_RESULT_DISPLAY = "mcp:CallToolResult|mcp:ServerError";
+    private static final String LIST_TOOLS_RESULT_DISPLAY = "mcp:ListToolsResult|mcp:ServerError";
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext context) {
+        ServiceDeclarationNode serviceNode = (ServiceDeclarationNode) context.node();
+        Optional<Symbol> symbol = context.semanticModel().symbol(serviceNode);
+        if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.SERVICE_DECLARATION) {
+            return;
+        }
+        if (!isStreamableHttpAdvancedService((ServiceDeclarationSymbol) symbol.get())) {
+            return;
+        }
+
+        Location serviceLocation = serviceNode.location();
+        FunctionDefinitionNode onCallTool = null;
+        FunctionDefinitionNode onListTools = null;
+
+        // Locate the two known remote methods; any other remote method is unsupported.
+        for (Node member : serviceNode.members()) {
+            if (!(member instanceof FunctionDefinitionNode functionNode) || !hasRemoteQualifier(functionNode)) {
+                continue;
+            }
+            String methodName = functionNode.functionName().text();
+            if (ON_CALL_TOOL.equals(methodName)) {
+                onCallTool = functionNode;
+            } else if (ON_LIST_TOOLS.equals(methodName)) {
+                onListTools = functionNode;
+            } else {
+                report(context, CompilationDiagnostic.ADVANCED_UNKNOWN_REMOTE_METHOD,
+                        functionNode.location(), methodName);
+            }
+        }
+
+        if (onCallTool == null) {
+            report(context, CompilationDiagnostic.ADVANCED_SERVICE_MISSING_METHOD, serviceLocation, ON_CALL_TOOL);
+        } else {
+            validateMethod(context, onCallTool, ON_CALL_TOOL, true);
+        }
+
+        if (onListTools == null) {
+            report(context, CompilationDiagnostic.ADVANCED_SERVICE_MISSING_METHOD, serviceLocation, ON_LIST_TOOLS);
+        } else {
+            validateMethod(context, onListTools, ON_LIST_TOOLS, false);
+        }
+    }
+
+    private static boolean isStreamableHttpAdvancedService(ServiceDeclarationSymbol serviceSymbol) {
+        Optional<TypeSymbol> typeDescriptor = serviceSymbol.typeDescriptor();
+        return typeDescriptor.isPresent()
+                && Utils.STREAMABLE_HTTP_ADVANCED_SERVICE_NAME.equals(typeDescriptor.get().getName().orElse(""))
+                && Utils.isMcpModuleSymbol(typeDescriptor.get());
+    }
+
+    private static boolean hasRemoteQualifier(FunctionDefinitionNode functionNode) {
+        return functionNode.qualifierList().stream()
+                .anyMatch(token -> token.kind() == SyntaxKind.REMOTE_KEYWORD);
+    }
+
+    private void validateMethod(SyntaxNodeAnalysisContext context, FunctionDefinitionNode functionNode,
+                                String methodName, boolean isCallTool) {
+        Optional<Symbol> symbol = context.semanticModel().symbol(functionNode);
+        if (symbol.isEmpty() || !(symbol.get() instanceof FunctionSymbol functionSymbol)) {
+            return;
+        }
+        FunctionTypeSymbol functionType = functionSymbol.typeDescriptor();
+        Location location = functionNode.location();
+
+        int callToolParamsCount = 0;
+        boolean hasHeaders = false;
+        boolean hasRequest = false;
+        boolean hasSession = false;
+
+        for (ParameterSymbol parameter : functionType.params().orElse(List.of())) {
+            TypeSymbol type = parameter.typeDescriptor();
+            String paramName = parameter.getName().orElse(Utils.UNKNOWN_SYMBOL);
+            Location paramLocation = parameter.getLocation().orElse(location);
+
+            if (Utils.hasHttpHeaderAnnotation(parameter)) {
+                if (!Utils.isValidHeaderParamType(type, context)) {
+                    report(context, CompilationDiagnostic.INVALID_HEADER_PARAMETER_TYPE, paramLocation,
+                            methodName, paramName);
+                }
+            } else if (Utils.isHttpHeadersType(type)) {
+                if (hasHeaders) {
+                    report(context, CompilationDiagnostic.DUPLICATE_PARAMETER, paramLocation,
+                            methodName, paramName, HTTP_HEADERS_DISPLAY);
+                }
+                hasHeaders = true;
+            } else if (Utils.isHttpRequestType(type)) {
+                if (hasRequest) {
+                    report(context, CompilationDiagnostic.DUPLICATE_PARAMETER, paramLocation,
+                            methodName, paramName, HTTP_REQUEST_DISPLAY);
+                }
+                hasRequest = true;
+            } else if (isCallTool && Utils.isCallToolParamsType(type)) {
+                callToolParamsCount++;
+            } else if (isCallTool && isSessionParam(type)) {
+                if (hasSession) {
+                    report(context, CompilationDiagnostic.DUPLICATE_PARAMETER, paramLocation,
+                            methodName, paramName, SESSION_DISPLAY);
+                }
+                hasSession = true;
+            } else {
+                report(context, CompilationDiagnostic.INVALID_PARAMETER_TYPE, paramLocation,
+                        methodName, paramName, Utils.ADVANCED_SUPPORTED_PARAM_TYPES);
+            }
+        }
+
+        if (isCallTool && callToolParamsCount != 1) {
+            report(context, CompilationDiagnostic.ADVANCED_ON_CALL_TOOL_PARAMS, location, methodName);
+        }
+
+        String expectedResultType = isCallTool
+                ? Utils.CALL_TOOL_RESULT_TYPE_NAME : Utils.LIST_TOOLS_RESULT_TYPE_NAME;
+        String expectedDisplay = isCallTool ? CALL_TOOL_RESULT_DISPLAY : LIST_TOOLS_RESULT_DISPLAY;
+        if (!returnTypeContains(functionType, expectedResultType)) {
+            report(context, CompilationDiagnostic.ADVANCED_INVALID_RETURN_TYPE, location, methodName, expectedDisplay);
+        }
+    }
+
+    /**
+     * Returns whether the type is {@code mcp:Session} or a nilable {@code mcp:Session?}. Session is typically declared
+     * nilable because it is absent in stateless mode.
+     */
+    private static boolean isSessionParam(TypeSymbol type) {
+        if (Utils.isSessionType(type)) {
+            return true;
+        }
+        if (type.typeKind() != TypeDescKind.UNION) {
+            return false;
+        }
+        List<TypeSymbol> nonNilMembers = ((UnionTypeSymbol) type).memberTypeDescriptors().stream()
+                .filter(member -> member.typeKind() != TypeDescKind.NIL)
+                .toList();
+        return nonNilMembers.size() == 1 && Utils.isSessionType(nonNilMembers.get(0));
+    }
+
+    private static boolean returnTypeContains(FunctionTypeSymbol functionType, String typeName) {
+        return functionType.returnTypeDescriptor()
+                .map(returnType -> typeMatches(returnType, typeName))
+                .orElse(false);
+    }
+
+    private static boolean typeMatches(TypeSymbol type, String typeName) {
+        if (type.typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) type).memberTypeDescriptors().stream()
+                    .anyMatch(member -> typeMatches(member, typeName));
+        }
+        if (typeName.equals(type.getName().orElse("")) && Utils.isMcpModuleSymbol(type)) {
+            return true;
+        }
+        if (type.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return typeMatches(((TypeReferenceTypeSymbol) type).typeDescriptor(), typeName);
+        }
+        return false;
+    }
+
+    private void report(SyntaxNodeAnalysisContext context, CompilationDiagnostic diagnostic, Location location,
+                        Object... args) {
+        context.reportDiagnostic(CompilationDiagnostic.getDiagnostic(diagnostic, location, args));
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/AdvancedServiceAnalysisTask.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/AdvancedServiceAnalysisTask.java
@@ -158,8 +158,10 @@ public class AdvancedServiceAnalysisTask implements AnalysisTask<SyntaxNodeAnaly
                 }
                 hasSession = true;
             } else {
+                String supportedTypes = isCallTool
+                        ? Utils.ADVANCED_SUPPORTED_PARAM_TYPES : Utils.ADVANCED_LIST_TOOLS_SUPPORTED_PARAM_TYPES;
                 report(context, CompilationDiagnostic.INVALID_PARAMETER_TYPE, paramLocation,
-                        methodName, paramName, Utils.ADVANCED_SUPPORTED_PARAM_TYPES);
+                        methodName, paramName, supportedTypes);
             }
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/McpCodeModifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/McpCodeModifier.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.ballerina.compiler.syntax.tree.SyntaxKind.OBJECT_METHOD_DEFINITION;
+import static io.ballerina.compiler.syntax.tree.SyntaxKind.SERVICE_DECLARATION;
 
 /**
  * Code modifier for processing MCP tool annotations on remote functions.
@@ -40,6 +41,7 @@ public class McpCodeModifier extends CodeModifier {
     public void init(CodeModifierContext codeModifierContext) {
         codeModifierContext.addSyntaxNodeAnalysisTask(new RemoteFunctionAnalysisTask(modifierContextMap),
                 OBJECT_METHOD_DEFINITION);
+        codeModifierContext.addSyntaxNodeAnalysisTask(new AdvancedServiceAnalysisTask(), SERVICE_DECLARATION);
         codeModifierContext.addSourceModifierTask(new McpSourceModifier(modifierContextMap));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import static io.ballerina.stdlib.mcp.plugin.RemoteFunctionAnalysisTask.EMPTY_STRING;
 import static io.ballerina.stdlib.mcp.plugin.Utils.hasHttpHeaderAnnotation;
 import static io.ballerina.stdlib.mcp.plugin.Utils.isHttpHeadersType;
+import static io.ballerina.stdlib.mcp.plugin.Utils.isHttpRequestType;
 import static io.ballerina.stdlib.mcp.plugin.Utils.isSessionType;
 
 /**
@@ -63,10 +64,11 @@ public class SchemaUtils {
         TypeMapper typeMapper = new TypeMapperImpl(context);
         for (ParameterSymbol parameterSymbol : parameterSymbolList) {
             try {
-                // Session, http:Headers, and @http:Header parameters are injected by
-                // the runtime and are not part of the tool input schema
+                // Session, http:Headers, http:Request, and @http:Header parameters are injected
+                // by the runtime and are not part of the tool input schema
                 if (isSessionType(parameterSymbol.typeDescriptor())
                         || isHttpHeadersType(parameterSymbol.typeDescriptor())
+                        || isHttpRequestType(parameterSymbol.typeDescriptor())
                         || hasHttpHeaderAnnotation(parameterSymbol)) {
                     continue;
                 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.mcp.plugin.RemoteFunctionAnalysisTask.EMPTY_STRING;
+import static io.ballerina.stdlib.mcp.plugin.Utils.isHttpHeadersType;
 import static io.ballerina.stdlib.mcp.plugin.Utils.isSessionType;
 
 /**
@@ -61,7 +62,10 @@ public class SchemaUtils {
         TypeMapper typeMapper = new TypeMapperImpl(context);
         for (ParameterSymbol parameterSymbol : parameterSymbolList) {
             try {
-                if (isSessionType(parameterSymbol.typeDescriptor())) {
+                // Session and http:Headers parameters are injected by the runtime
+                // and are not part of the tool input schema
+                if (isSessionType(parameterSymbol.typeDescriptor())
+                        || isHttpHeadersType(parameterSymbol.typeDescriptor())) {
                     continue;
                 }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/SchemaUtils.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.mcp.plugin.RemoteFunctionAnalysisTask.EMPTY_STRING;
+import static io.ballerina.stdlib.mcp.plugin.Utils.hasHttpHeaderAnnotation;
 import static io.ballerina.stdlib.mcp.plugin.Utils.isHttpHeadersType;
 import static io.ballerina.stdlib.mcp.plugin.Utils.isSessionType;
 
@@ -62,10 +63,11 @@ public class SchemaUtils {
         TypeMapper typeMapper = new TypeMapperImpl(context);
         for (ParameterSymbol parameterSymbol : parameterSymbolList) {
             try {
-                // Session and http:Headers parameters are injected by the runtime
-                // and are not part of the tool input schema
+                // Session, http:Headers, and @http:Header parameters are injected by
+                // the runtime and are not part of the tool input schema
                 if (isSessionType(parameterSymbol.typeDescriptor())
-                        || isHttpHeadersType(parameterSymbol.typeDescriptor())) {
+                        || isHttpHeadersType(parameterSymbol.typeDescriptor())
+                        || hasHttpHeaderAnnotation(parameterSymbol)) {
                     continue;
                 }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -86,6 +86,9 @@ public class Utils {
                     + "an 'http:Headers' parameter, an 'http:Request' parameter, or '@http:Header' parameters";
     public static final String ADVANCED_SUPPORTED_PARAM_TYPES =
             "'mcp:CallToolParams', 'mcp:Session', 'http:Headers', 'http:Request', or an '@http:Header' parameter";
+    // 'onListTools' does not accept 'mcp:CallToolParams' or 'mcp:Session'.
+    public static final String ADVANCED_LIST_TOOLS_SUPPORTED_PARAM_TYPES =
+            "'http:Headers', 'http:Request', or an '@http:Header' parameter";
 
     public enum SessionMode {
         STATEFUL("stateful"),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -64,12 +64,14 @@ public class Utils {
     public static final String TOOL_ANNOTATION_NAME = "Tool";
     public static final String MCP_PACKAGE_NAME = "mcp";
     public static final String MCP_BASIC_SERVICE_NAME = "Service";
+    public static final String STREAMABLE_HTTP_BASIC_SERVICE_NAME = "StreamableHttpService";
     public static final String SESSION_TYPE_NAME = "Session";
     public static final String HTTP_PACKAGE_NAME = "http";
     public static final String HEADERS_TYPE_NAME = "Headers";
     public static final String HEADER_ANNOTATION_NAME = "Header";
     public static final String UNKNOWN_SYMBOL = "unknown";
     public static final String SERVICE_CONFIG_ANNOTATION_NAME = "ServiceConfig";
+    public static final String STREAMABLE_HTTP_SERVICE_CONFIG_ANNOTATION_NAME = "StreamableHttpServiceConfig";
     public static final String SESSION_MODE_FIELD = "sessionMode";
 
     public enum SessionMode {
@@ -172,10 +174,28 @@ public class Utils {
                 .anyMatch(Utils::isListenerFromMcpModule);
 
         boolean isServiceType = serviceSymbol.typeDescriptor()
-                .flatMap(type -> type.getName().map(MCP_BASIC_SERVICE_NAME::equals))
+                .flatMap(TypeSymbol::getName)
+                .map(name -> MCP_BASIC_SERVICE_NAME.equals(name)
+                        || STREAMABLE_HTTP_BASIC_SERVICE_NAME.equals(name))
                 .orElse(false);
 
         return isFromMcpModule && isServiceType;
+    }
+
+    /**
+     * Returns whether the service enclosing the given remote function is an `mcp:StreamableHttpService` — the only
+     * basic service type whose tools may bind transport-specific (HTTP) request information.
+     */
+    static boolean isStreamableHttpService(FunctionDefinitionNode functionDefinitionNode,
+                                           SemanticModel semanticModel) {
+        Optional<Symbol> parentSymbol = semanticModel.symbol(functionDefinitionNode.parent());
+        if (parentSymbol.isEmpty() || parentSymbol.get().kind() != SymbolKind.SERVICE_DECLARATION) {
+            return false;
+        }
+        return ((ServiceDeclarationSymbol) parentSymbol.get()).typeDescriptor()
+                .flatMap(TypeSymbol::getName)
+                .map(STREAMABLE_HTTP_BASIC_SERVICE_NAME::equals)
+                .orElse(false);
     }
 
     public static boolean isAnydataType(TypeSymbol typeSymbol, SyntaxNodeAnalysisContext context) {
@@ -204,6 +224,20 @@ public class Utils {
             String parameterName = parameterSymbol.getName().orElse(UNKNOWN_SYMBOL);
 
             boolean isSessionType = isSessionType(parameterType);
+
+            // Header binding and http:Headers parameters expose transport-specific (HTTP)
+            // request information, so they are only allowed in an mcp:StreamableHttpService.
+            // (The type system separately guarantees an mcp:StreamableHttpService can only be
+            // attached to an mcp:StreamableHttpListener.)
+            boolean isHttpBoundParam = hasHttpHeaderAnnotation(parameterSymbol) || isHttpHeadersType(parameterType);
+            if (isHttpBoundParam && !isStreamableHttpService(functionDefinitionNode, context.semanticModel())) {
+                Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
+                        CompilationDiagnostic.TRANSPORT_SPECIFIC_PARAM_NOT_ALLOWED,
+                        parameterSymbol.getLocation().orElse(alternativeLocation),
+                        functionName, parameterName);
+                context.reportDiagnostic(diagnostic);
+                return false;
+            }
 
             if (hasHttpHeaderAnnotation(parameterSymbol)) {
                 if (!isValidHeaderParamType(parameterType, context)) {
@@ -373,20 +407,36 @@ public class Utils {
             return SessionMode.AUTO;
         }
 
-        // Find the MCP ServiceConfig annotation
-        AnnotationNode serviceConfigAnnotation = null;
-        for (AnnotationNode annotation : serviceNode.metadata().get().annotations()) {
-            if (isMcpServiceConfigAnnotation(annotation)) {
-                serviceConfigAnnotation = annotation;
-                break;
-            }
+        // The transport-specific @mcp:StreamableHttpConfig annotation takes precedence over
+        // the deprecated sessionMode field of @mcp:ServiceConfig
+        AnnotationNode transportConfigAnnotation =
+                findMcpAnnotation(serviceNode, STREAMABLE_HTTP_SERVICE_CONFIG_ANNOTATION_NAME);
+        if (transportConfigAnnotation != null) {
+            return getSessionModeFieldValue(transportConfigAnnotation, semanticModel);
         }
 
-        if (serviceConfigAnnotation == null || serviceConfigAnnotation.annotValue().isEmpty()) {
+        AnnotationNode serviceConfigAnnotation = findMcpAnnotation(serviceNode, SERVICE_CONFIG_ANNOTATION_NAME);
+        if (serviceConfigAnnotation != null) {
+            return getSessionModeFieldValue(serviceConfigAnnotation, semanticModel);
+        }
+        return SessionMode.AUTO;
+    }
+
+    private static AnnotationNode findMcpAnnotation(ServiceDeclarationNode serviceNode, String annotationName) {
+        for (AnnotationNode annotation : serviceNode.metadata().get().annotations()) {
+            if (isMcpAnnotation(annotation, annotationName)) {
+                return annotation;
+            }
+        }
+        return null;
+    }
+
+    private static SessionMode getSessionModeFieldValue(AnnotationNode annotationNode, SemanticModel semanticModel) {
+        if (annotationNode.annotValue().isEmpty()) {
             return SessionMode.AUTO;
         }
 
-        SeparatedNodeList<MappingFieldNode> fields = serviceConfigAnnotation.annotValue().get().fields();
+        SeparatedNodeList<MappingFieldNode> fields = annotationNode.annotValue().get().fields();
         for (MappingFieldNode field : fields) {
             if (field.kind() == SyntaxKind.SPECIFIC_FIELD) {
                 SpecificFieldNode specificField = (SpecificFieldNode) field;
@@ -432,7 +482,7 @@ public class Utils {
         return SessionMode.AUTO;
     }
 
-    private static boolean isMcpServiceConfigAnnotation(AnnotationNode annotation) {
+    private static boolean isMcpAnnotation(AnnotationNode annotation, String annotationName) {
         if (annotation.annotReference().kind() != SyntaxKind.QUALIFIED_NAME_REFERENCE) {
             return false;
         }
@@ -441,7 +491,7 @@ public class Utils {
         String modulePrefix = qualifiedRef.modulePrefix().text();
         String identifier = qualifiedRef.identifier().text();
 
-        return MCP_PACKAGE_NAME.equals(modulePrefix) && SERVICE_CONFIG_ANNOTATION_NAME.equals(identifier);
+        return MCP_PACKAGE_NAME.equals(modulePrefix) && annotationName.equals(identifier);
     }
 
     private static boolean isListenerFromMcpModule(TypeSymbol typeSymbol) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -65,7 +65,11 @@ public class Utils {
     public static final String MCP_PACKAGE_NAME = "mcp";
     public static final String MCP_BASIC_SERVICE_NAME = "Service";
     public static final String STREAMABLE_HTTP_BASIC_SERVICE_NAME = "StreamableHttpService";
+    public static final String STREAMABLE_HTTP_ADVANCED_SERVICE_NAME = "StreamableHttpAdvancedService";
     public static final String SESSION_TYPE_NAME = "Session";
+    public static final String CALL_TOOL_PARAMS_TYPE_NAME = "CallToolParams";
+    public static final String CALL_TOOL_RESULT_TYPE_NAME = "CallToolResult";
+    public static final String LIST_TOOLS_RESULT_TYPE_NAME = "ListToolsResult";
     public static final String HTTP_PACKAGE_NAME = "http";
     public static final String HEADERS_TYPE_NAME = "Headers";
     public static final String REQUEST_TYPE_NAME = "Request";
@@ -74,6 +78,13 @@ public class Utils {
     public static final String SERVICE_CONFIG_ANNOTATION_NAME = "ServiceConfig";
     public static final String STREAMABLE_HTTP_SERVICE_CONFIG_ANNOTATION_NAME = "StreamableHttpServiceConfig";
     public static final String SESSION_MODE_FIELD = "sessionMode";
+
+    // Human-readable lists of supported parameter types, used in the INVALID_PARAMETER_TYPE diagnostic.
+    public static final String BASIC_TOOL_SUPPORTED_PARAM_TYPES =
+            "'anydata' tool parameters, a first 'mcp:Session' parameter, an 'http:Headers' parameter, "
+                    + "an 'http:Request' parameter, or '@http:Header' parameters";
+    public static final String ADVANCED_SUPPORTED_PARAM_TYPES =
+            "'mcp:CallToolParams', 'mcp:Session', 'http:Headers', 'http:Request', or an '@http:Header' parameter";
 
     public enum SessionMode {
         STATEFUL("stateful"),
@@ -313,7 +324,7 @@ public class Utils {
                 Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
                         CompilationDiagnostic.INVALID_PARAMETER_TYPE,
                         parameterSymbol.getLocation().orElse(alternativeLocation),
-                        functionName, parameterName);
+                        functionName, parameterName, BASIC_TOOL_SUPPORTED_PARAM_TYPES);
                 context.reportDiagnostic(diagnostic);
                 return false;
             }
@@ -324,6 +335,11 @@ public class Utils {
 
     static boolean isSessionType(TypeSymbol typeSymbol) {
         return SESSION_TYPE_NAME.equals(typeSymbol.getName().orElse(""))
+                && isMcpModuleSymbol(typeSymbol);
+    }
+
+    static boolean isCallToolParamsType(TypeSymbol typeSymbol) {
+        return CALL_TOOL_PARAMS_TYPE_NAME.equals(typeSymbol.getName().orElse(""))
                 && isMcpModuleSymbol(typeSymbol);
     }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -20,14 +20,19 @@ package io.ballerina.stdlib.mcp.plugin;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.ServiceDeclarationSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.values.ConstantValue;
@@ -54,6 +59,7 @@ import java.util.Optional;
  * Util class for the compiler plugin.
  */
 public class Utils {
+
     public static final String BALLERINA_ORG = "ballerina";
     public static final String TOOL_ANNOTATION_NAME = "Tool";
     public static final String MCP_PACKAGE_NAME = "mcp";
@@ -61,6 +67,7 @@ public class Utils {
     public static final String SESSION_TYPE_NAME = "Session";
     public static final String HTTP_PACKAGE_NAME = "http";
     public static final String HEADERS_TYPE_NAME = "Headers";
+    public static final String HEADER_ANNOTATION_NAME = "Header";
     public static final String UNKNOWN_SYMBOL = "unknown";
     public static final String SERVICE_CONFIG_ANNOTATION_NAME = "ServiceConfig";
     public static final String SESSION_MODE_FIELD = "sessionMode";
@@ -128,7 +135,6 @@ public class Utils {
     public static String escapeDoubleQuotes(String input) {
         return input.replace("\"", "\\\"");
     }
-
 
     public static String addDoubleQuotes(String input) {
         return "\"" + input + "\"";
@@ -199,6 +205,18 @@ public class Utils {
 
             boolean isSessionType = isSessionType(parameterType);
 
+            if (hasHttpHeaderAnnotation(parameterSymbol)) {
+                if (!isValidHeaderParamType(parameterType, context)) {
+                    Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
+                            CompilationDiagnostic.INVALID_HEADER_PARAMETER_TYPE,
+                            parameterSymbol.getLocation().orElse(alternativeLocation),
+                            functionName, parameterName);
+                    context.reportDiagnostic(diagnostic);
+                    return false;
+                }
+                continue;
+            }
+
             if (isHttpHeadersType(parameterType)) {
                 if (hasHeadersParam) {
                     Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
@@ -261,6 +279,91 @@ public class Utils {
                 && typeSymbol.getModule().isPresent()
                 && HTTP_PACKAGE_NAME.equals(typeSymbol.getModule().get().id().moduleName())
                 && BALLERINA_ORG.equals(typeSymbol.getModule().get().id().orgName());
+    }
+
+    static boolean hasHttpHeaderAnnotation(ParameterSymbol parameterSymbol) {
+        return parameterSymbol.annotations().stream()
+                .anyMatch(annotation -> HEADER_ANNOTATION_NAME.equals(annotation.getName().orElse(""))
+                        && annotation.getModule().isPresent()
+                        && HTTP_PACKAGE_NAME.equals(annotation.getModule().get().id().moduleName())
+                        && BALLERINA_ORG.equals(annotation.getModule().get().id().orgName()));
+    }
+
+    /**
+     * Validates the type of a '@http:Header' annotated parameter consistently with http services: 'string', 'int',
+     * 'float', 'decimal', 'boolean', arrays of those types, their nilable variants, or a closed record consisting of
+     * those types.
+     */
+    static boolean isValidHeaderParamType(TypeSymbol typeSymbol, SyntaxNodeAnalysisContext context) {
+        if (isValidHeaderValueType(typeSymbol, context)) {
+            return true;
+        }
+        TypeSymbol rawType = getRawType(getNonNilType(typeSymbol));
+        if (rawType instanceof RecordTypeSymbol recordTypeSymbol) {
+            if (recordTypeSymbol.restTypeDescriptor().isPresent()) {
+                return false;
+            }
+            return recordTypeSymbol.fieldDescriptors().values().stream()
+                    .allMatch(field -> isValidHeaderValueType(field.typeDescriptor(), context));
+        }
+        return false;
+    }
+
+    private static boolean isValidHeaderValueType(TypeSymbol typeSymbol, SyntaxNodeAnalysisContext context) {
+        TypeSymbol rawType = getRawType(typeSymbol);
+        if (rawType.typeKind() == TypeDescKind.UNION) {
+            // Consistent with http: a union is valid only when all its non-nil members share
+            // a single basic type (covers nilable variants, enums, and finite string unions)
+            var nonNilMembers = ((UnionTypeSymbol) rawType).memberTypeDescriptors().stream()
+                    .filter(member -> member.typeKind() != TypeDescKind.NIL)
+                    .toList();
+            if (nonNilMembers.isEmpty()) {
+                return false;
+            }
+            if (nonNilMembers.size() == 1) {
+                return isValidHeaderValueType(nonNilMembers.getFirst(), context);
+            }
+            var types = context.semanticModel().types();
+            for (TypeSymbol basicType : new TypeSymbol[]{types.STRING, types.INT, types.FLOAT,
+                    types.DECIMAL, types.BOOLEAN}) {
+                if (nonNilMembers.stream().allMatch(member -> member.subtypeOf(basicType))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (rawType.typeKind() == TypeDescKind.ARRAY) {
+            return isValidHeaderValueType(((ArrayTypeSymbol) rawType).memberTypeDescriptor(), context);
+        }
+        return isBasicType(rawType, context);
+    }
+
+    private static boolean isBasicType(TypeSymbol typeSymbol, SyntaxNodeAnalysisContext context) {
+        var types = context.semanticModel().types();
+        TypeSymbol rawType = getRawType(typeSymbol);
+        return rawType.subtypeOf(types.STRING) || rawType.subtypeOf(types.INT)
+                || rawType.subtypeOf(types.FLOAT) || rawType.subtypeOf(types.DECIMAL)
+                || rawType.subtypeOf(types.BOOLEAN);
+    }
+
+    private static TypeSymbol getNonNilType(TypeSymbol typeSymbol) {
+        TypeSymbol rawType = getRawType(typeSymbol);
+        if (rawType.typeKind() != TypeDescKind.UNION) {
+            return typeSymbol;
+        }
+        var nonNilMembers = ((UnionTypeSymbol) rawType).memberTypeDescriptors().stream()
+                .filter(member -> member.typeKind() != TypeDescKind.NIL)
+                .toList();
+        return nonNilMembers.size() == 1 ? nonNilMembers.get(0) : typeSymbol;
+    }
+
+    private static TypeSymbol getRawType(TypeSymbol typeSymbol) {
+        if (typeSymbol.typeKind() == TypeDescKind.INTERSECTION) {
+            return getRawType(((IntersectionTypeSymbol) typeSymbol).effectiveTypeDescriptor());
+        }
+        return typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE
+                ? getRawType(((TypeReferenceTypeSymbol) typeSymbol).typeDescriptor())
+                : typeSymbol;
     }
 
     private static SessionMode getSessionMode(FunctionDefinitionNode functionDefinitionNode,

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -68,6 +68,7 @@ public class Utils {
     public static final String SESSION_TYPE_NAME = "Session";
     public static final String HTTP_PACKAGE_NAME = "http";
     public static final String HEADERS_TYPE_NAME = "Headers";
+    public static final String REQUEST_TYPE_NAME = "Request";
     public static final String HEADER_ANNOTATION_NAME = "Header";
     public static final String UNKNOWN_SYMBOL = "unknown";
     public static final String SERVICE_CONFIG_ANNOTATION_NAME = "ServiceConfig";
@@ -115,6 +116,12 @@ public class Utils {
     public static boolean isMcpModuleSymbol(Symbol symbol) {
         return symbol.getModule().isPresent()
                 && MCP_PACKAGE_NAME.equals(symbol.getModule().get().id().moduleName())
+                && BALLERINA_ORG.equals(symbol.getModule().get().id().orgName());
+    }
+
+    private static boolean isHttpModuleSymbol(Symbol symbol) {
+        return symbol.getModule().isPresent()
+                && HTTP_PACKAGE_NAME.equals(symbol.getModule().get().id().moduleName())
                 && BALLERINA_ORG.equals(symbol.getModule().get().id().orgName());
     }
 
@@ -217,6 +224,7 @@ public class Utils {
         var parameterSymbolList = functionTypeSymbol.params().get();
         boolean hasSessionParam = false;
         boolean hasHeadersParam = false;
+        boolean hasRequestParam = false;
 
         for (int i = 0; i < parameterSymbolList.size(); i++) {
             ParameterSymbol parameterSymbol = parameterSymbolList.get(i);
@@ -225,11 +233,12 @@ public class Utils {
 
             boolean isSessionType = isSessionType(parameterType);
 
-            // Header binding and http:Headers parameters expose transport-specific (HTTP)
-            // request information, so they are only allowed in an mcp:StreamableHttpService.
+            // Header binding, http:Headers, and http:Request parameters expose transport-specific
+            // (HTTP) request information, so they are only allowed in an mcp:StreamableHttpService.
             // (The type system separately guarantees an mcp:StreamableHttpService can only be
             // attached to an mcp:StreamableHttpListener.)
-            boolean isHttpBoundParam = hasHttpHeaderAnnotation(parameterSymbol) || isHttpHeadersType(parameterType);
+            boolean isHttpBoundParam = hasHttpHeaderAnnotation(parameterSymbol) || isHttpHeadersType(parameterType)
+                    || isHttpRequestType(parameterType);
             if (isHttpBoundParam && !isStreamableHttpService(functionDefinitionNode, context.semanticModel())) {
                 Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
                         CompilationDiagnostic.TRANSPORT_SPECIFIC_PARAM_NOT_ALLOWED,
@@ -254,13 +263,23 @@ public class Utils {
             if (isHttpHeadersType(parameterType)) {
                 if (hasHeadersParam) {
                     Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
-                            CompilationDiagnostic.DUPLICATE_HEADERS_PARAM,
+                            CompilationDiagnostic.DUPLICATE_PARAMETER,
                             parameterSymbol.getLocation().orElse(alternativeLocation),
-                            functionName, parameterName);
+                            functionName, parameterName, HTTP_PACKAGE_NAME + ":" + HEADERS_TYPE_NAME);
                     context.reportDiagnostic(diagnostic);
                     return false;
                 }
                 hasHeadersParam = true;
+            } else if (isHttpRequestType(parameterType)) {
+                if (hasRequestParam) {
+                    Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
+                            CompilationDiagnostic.DUPLICATE_PARAMETER,
+                            parameterSymbol.getLocation().orElse(alternativeLocation),
+                            functionName, parameterName, HTTP_PACKAGE_NAME + ":" + REQUEST_TYPE_NAME);
+                    context.reportDiagnostic(diagnostic);
+                    return false;
+                }
+                hasRequestParam = true;
             } else if (isSessionType) {
                 if (hasSessionParam) {
                     Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
@@ -310,17 +329,18 @@ public class Utils {
 
     static boolean isHttpHeadersType(TypeSymbol typeSymbol) {
         return HEADERS_TYPE_NAME.equals(typeSymbol.getName().orElse(""))
-                && typeSymbol.getModule().isPresent()
-                && HTTP_PACKAGE_NAME.equals(typeSymbol.getModule().get().id().moduleName())
-                && BALLERINA_ORG.equals(typeSymbol.getModule().get().id().orgName());
+                && isHttpModuleSymbol(typeSymbol);
+    }
+
+    static boolean isHttpRequestType(TypeSymbol typeSymbol) {
+        return REQUEST_TYPE_NAME.equals(typeSymbol.getName().orElse(""))
+                && isHttpModuleSymbol(typeSymbol);
     }
 
     static boolean hasHttpHeaderAnnotation(ParameterSymbol parameterSymbol) {
         return parameterSymbol.annotations().stream()
                 .anyMatch(annotation -> HEADER_ANNOTATION_NAME.equals(annotation.getName().orElse(""))
-                        && annotation.getModule().isPresent()
-                        && HTTP_PACKAGE_NAME.equals(annotation.getModule().get().id().moduleName())
-                        && BALLERINA_ORG.equals(annotation.getModule().get().id().orgName()));
+                        && isHttpModuleSymbol(annotation));
     }
 
     /**

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -59,6 +59,8 @@ public class Utils {
     public static final String MCP_PACKAGE_NAME = "mcp";
     public static final String MCP_BASIC_SERVICE_NAME = "Service";
     public static final String SESSION_TYPE_NAME = "Session";
+    public static final String HTTP_PACKAGE_NAME = "http";
+    public static final String HEADERS_TYPE_NAME = "Headers";
     public static final String UNKNOWN_SYMBOL = "unknown";
     public static final String SERVICE_CONFIG_ANNOTATION_NAME = "ServiceConfig";
     public static final String SESSION_MODE_FIELD = "sessionMode";
@@ -188,6 +190,7 @@ public class Utils {
 
         var parameterSymbolList = functionTypeSymbol.params().get();
         boolean hasSessionParam = false;
+        boolean hasHeadersParam = false;
 
         for (int i = 0; i < parameterSymbolList.size(); i++) {
             ParameterSymbol parameterSymbol = parameterSymbolList.get(i);
@@ -196,7 +199,17 @@ public class Utils {
 
             boolean isSessionType = isSessionType(parameterType);
 
-            if (isSessionType) {
+            if (isHttpHeadersType(parameterType)) {
+                if (hasHeadersParam) {
+                    Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
+                            CompilationDiagnostic.DUPLICATE_HEADERS_PARAM,
+                            parameterSymbol.getLocation().orElse(alternativeLocation),
+                            functionName, parameterName);
+                    context.reportDiagnostic(diagnostic);
+                    return false;
+                }
+                hasHeadersParam = true;
+            } else if (isSessionType) {
                 if (hasSessionParam) {
                     Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
                             CompilationDiagnostic.SESSION_PARAM_MUST_BE_FIRST,
@@ -241,6 +254,13 @@ public class Utils {
     static boolean isSessionType(TypeSymbol typeSymbol) {
         return SESSION_TYPE_NAME.equals(typeSymbol.getName().orElse(""))
                 && isMcpModuleSymbol(typeSymbol);
+    }
+
+    static boolean isHttpHeadersType(TypeSymbol typeSymbol) {
+        return HEADERS_TYPE_NAME.equals(typeSymbol.getName().orElse(""))
+                && typeSymbol.getModule().isPresent()
+                && HTTP_PACKAGE_NAME.equals(typeSymbol.getModule().get().id().moduleName())
+                && BALLERINA_ORG.equals(typeSymbol.getModule().get().id().orgName());
     }
 
     private static SessionMode getSessionMode(FunctionDefinitionNode functionDefinitionNode,

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -35,7 +35,8 @@ public enum CompilationDiagnostic {
     SESSION_PARAM_MUST_BE_FIRST(DiagnosticMessage.ERROR_103, DiagnosticCode.MCP_103, ERROR),
     SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
     DUPLICATE_HEADERS_PARAM(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
-    INVALID_HEADER_PARAMETER_TYPE(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR);
+    INVALID_HEADER_PARAMETER_TYPE(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR),
+    TRANSPORT_SPECIFIC_PARAM_NOT_ALLOWED(DiagnosticMessage.ERROR_107, DiagnosticCode.MCP_107, ERROR);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -34,7 +34,7 @@ public enum CompilationDiagnostic {
     INVALID_PARAMETER_TYPE(DiagnosticMessage.ERROR_102, DiagnosticCode.MCP_102, ERROR),
     SESSION_PARAM_MUST_BE_FIRST(DiagnosticMessage.ERROR_103, DiagnosticCode.MCP_103, ERROR),
     SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
-    DUPLICATE_HEADERS_PARAM(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
+    DUPLICATE_PARAMETER(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
     INVALID_HEADER_PARAMETER_TYPE(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR),
     TRANSPORT_SPECIFIC_PARAM_NOT_ALLOWED(DiagnosticMessage.ERROR_107, DiagnosticCode.MCP_107, ERROR);
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -34,7 +34,8 @@ public enum CompilationDiagnostic {
     INVALID_PARAMETER_TYPE(DiagnosticMessage.ERROR_102, DiagnosticCode.MCP_102, ERROR),
     SESSION_PARAM_MUST_BE_FIRST(DiagnosticMessage.ERROR_103, DiagnosticCode.MCP_103, ERROR),
     SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
-    DUPLICATE_HEADERS_PARAM(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR);
+    DUPLICATE_HEADERS_PARAM(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
+    INVALID_HEADER_PARAMETER_TYPE(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -36,7 +36,11 @@ public enum CompilationDiagnostic {
     SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
     DUPLICATE_PARAMETER(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
     INVALID_HEADER_PARAMETER_TYPE(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR),
-    TRANSPORT_SPECIFIC_PARAM_NOT_ALLOWED(DiagnosticMessage.ERROR_107, DiagnosticCode.MCP_107, ERROR);
+    TRANSPORT_SPECIFIC_PARAM_NOT_ALLOWED(DiagnosticMessage.ERROR_107, DiagnosticCode.MCP_107, ERROR),
+    ADVANCED_SERVICE_MISSING_METHOD(DiagnosticMessage.ERROR_108, DiagnosticCode.MCP_108, ERROR),
+    ADVANCED_ON_CALL_TOOL_PARAMS(DiagnosticMessage.ERROR_109, DiagnosticCode.MCP_109, ERROR),
+    ADVANCED_INVALID_RETURN_TYPE(DiagnosticMessage.ERROR_110, DiagnosticCode.MCP_110, ERROR),
+    ADVANCED_UNKNOWN_REMOTE_METHOD(DiagnosticMessage.ERROR_111, DiagnosticCode.MCP_111, ERROR);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -33,7 +33,8 @@ public enum CompilationDiagnostic {
     UNABLE_TO_GENERATE_SCHEMA_FOR_FUNCTION(DiagnosticMessage.ERROR_101, DiagnosticCode.MCP_101, ERROR),
     INVALID_PARAMETER_TYPE(DiagnosticMessage.ERROR_102, DiagnosticCode.MCP_102, ERROR),
     SESSION_PARAM_MUST_BE_FIRST(DiagnosticMessage.ERROR_103, DiagnosticCode.MCP_103, ERROR),
-    SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR);
+    SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
+    DUPLICATE_HEADERS_PARAM(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR);
 
     private final String diagnostic;
     private final String diagnosticCode;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
@@ -28,5 +28,9 @@ public enum DiagnosticCode {
     MCP_104,
     MCP_105,
     MCP_106,
-    MCP_107
+    MCP_107,
+    MCP_108,
+    MCP_109,
+    MCP_110,
+    MCP_111
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
@@ -27,5 +27,6 @@ public enum DiagnosticCode {
     MCP_103,
     MCP_104,
     MCP_105,
-    MCP_106
+    MCP_106,
+    MCP_107
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
@@ -26,5 +26,6 @@ public enum DiagnosticCode {
     MCP_102,
     MCP_103,
     MCP_104,
-    MCP_105
+    MCP_105,
+    MCP_106
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticCode.java
@@ -25,5 +25,6 @@ public enum DiagnosticCode {
     MCP_101,
     MCP_102,
     MCP_103,
-    MCP_104
+    MCP_104,
+    MCP_105
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
@@ -24,9 +24,7 @@ package io.ballerina.stdlib.mcp.plugin.diagnostics;
 public enum DiagnosticMessage {
     ERROR_101("Failed to generate the parameter schema definition for the function ''{0}''." +
             " Specify the parameter schema manually using the `@mcp:McpTool` annotation's parameter field."),
-    ERROR_102("Parameter ''{1}'' in function ''{0}'' must be of type 'anydata'. " +
-            "Only the first parameter can be of type 'mcp:Session', and a single parameter " +
-            "of type 'http:Headers' is allowed."),
+    ERROR_102("Parameter ''{1}'' in function ''{0}'' has an unsupported type. Supported types are {2}."),
     ERROR_103("Session parameter ''{1}'' in function ''{0}'' must be the first parameter."),
     ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'."),
     ERROR_105("Duplicate parameter ''{1}'' in function ''{0}''. " +
@@ -36,7 +34,13 @@ public enum DiagnosticMessage {
             "the above types."),
     ERROR_107("Parameter ''{1}'' in function ''{0}'' accesses transport-specific properties, which are not " +
             "accessible in the transport-agnostic 'mcp:Service'. Use a transport-specific service type such " +
-            "as 'mcp:StreamableHttpService'.");
+            "as 'mcp:StreamableHttpService'."),
+    ERROR_108("A service of type 'mcp:StreamableHttpAdvancedService' must define a remote method ''{0}''."),
+    ERROR_109("Remote method ''{0}'' in an 'mcp:StreamableHttpAdvancedService' must declare exactly one " +
+            "parameter of type 'mcp:CallToolParams'."),
+    ERROR_110("Remote method ''{0}'' in an 'mcp:StreamableHttpAdvancedService' must return ''{1}''."),
+    ERROR_111("Remote method ''{0}'' is not supported in an 'mcp:StreamableHttpAdvancedService'. " +
+            "Only 'onListTools' and 'onCallTool' are allowed.");
 
     private final String message;
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
@@ -25,9 +25,12 @@ public enum DiagnosticMessage {
     ERROR_101("Failed to generate the parameter schema definition for the function ''{0}''." +
             " Specify the parameter schema manually using the `@mcp:McpTool` annotation's parameter field."),
     ERROR_102("Parameter ''{1}'' in function ''{0}'' must be of type 'anydata'. " +
-            "Only the first parameter can be of type 'mcp:Session'."),
+            "Only the first parameter can be of type 'mcp:Session', and a single parameter " +
+            "of type 'http:Headers' is allowed."),
     ERROR_103("Session parameter ''{1}'' in function ''{0}'' must be the first parameter."),
-    ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'.");
+    ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'."),
+    ERROR_105("Duplicate headers parameter ''{1}'' in function ''{0}''. " +
+            "Only one parameter of type 'http:Headers' is allowed.");
 
     private final String message;
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
@@ -29,8 +29,8 @@ public enum DiagnosticMessage {
             "of type 'http:Headers' is allowed."),
     ERROR_103("Session parameter ''{1}'' in function ''{0}'' must be the first parameter."),
     ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'."),
-    ERROR_105("Duplicate headers parameter ''{1}'' in function ''{0}''. " +
-            "Only one parameter of type 'http:Headers' is allowed."),
+    ERROR_105("Duplicate parameter ''{1}'' in function ''{0}''. " +
+            "Only one parameter of type ''{2}'' is allowed."),
     ERROR_106("Invalid type of header param ''{1}'' in function ''{0}'': expected one of the 'string', 'int', " +
             "'float', 'decimal', 'boolean' types, an array of the above types, or a record which consists of " +
             "the above types."),

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
@@ -33,7 +33,10 @@ public enum DiagnosticMessage {
             "Only one parameter of type 'http:Headers' is allowed."),
     ERROR_106("Invalid type of header param ''{1}'' in function ''{0}'': expected one of the 'string', 'int', " +
             "'float', 'decimal', 'boolean' types, an array of the above types, or a record which consists of " +
-            "the above types.");
+            "the above types."),
+    ERROR_107("Parameter ''{1}'' in function ''{0}'' accesses transport-specific properties, which are not " +
+            "accessible in the transport-agnostic 'mcp:Service'. Use a transport-specific service type such " +
+            "as 'mcp:StreamableHttpService'.");
 
     private final String message;
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/DiagnosticMessage.java
@@ -30,7 +30,10 @@ public enum DiagnosticMessage {
     ERROR_103("Session parameter ''{1}'' in function ''{0}'' must be the first parameter."),
     ERROR_104("Session parameter ''{1}'' in function ''{0}'' is not allowed when sessionMode is 'STATELESS'."),
     ERROR_105("Duplicate headers parameter ''{1}'' in function ''{0}''. " +
-            "Only one parameter of type 'http:Headers' is allowed.");
+            "Only one parameter of type 'http:Headers' is allowed."),
+    ERROR_106("Invalid type of header param ''{1}'' in function ''{0}'': expected one of the 'string', 'int', " +
+            "'float', 'decimal', 'boolean' types, an array of the above types, or a record which consists of " +
+            "the above types.");
 
     private final String message;
 

--- a/examples/servers/mcp-crypto-server/main.bal
+++ b/examples/servers/mcp-crypto-server/main.bal
@@ -20,9 +20,9 @@ import ballerina/log;
 import ballerina/mcp;
 import ballerina/time;
 
-listener mcp:Listener mcpListener = check new (9091);
+listener mcp:StreamableHttpListener mcpListener = check new (9091);
 
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {
         name: "MCP Crypto Server",
         version: "1.0.0"

--- a/examples/servers/mcp-shopping-server/main.bal
+++ b/examples/servers/mcp-shopping-server/main.bal
@@ -18,9 +18,9 @@ import ballerina/log;
 import ballerina/mcp;
 import ballerina/time;
 
-listener mcp:Listener mcpListener = check new (9092);
+listener mcp:StreamableHttpListener mcpListener = check new (9092);
 
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {
         name: "MCP Shopping Cart Server",
         version: "1.0.0"

--- a/examples/servers/mcp-weather-server/main.bal
+++ b/examples/servers/mcp-weather-server/main.bal
@@ -19,9 +19,9 @@ import ballerina/mcp;
 import ballerina/random;
 import ballerina/time;
 
-listener mcp:Listener mcpListener = check new (9090);
+listener mcp:StreamableHttpListener mcpListener = check new (9090);
 
-@mcp:ServiceConfig {
+@mcp:StreamableHttpServiceConfig {
     info: {
         name: "MCP Weather Server",
         version: "1.0.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ org.gradle.caching=true
 group=io.ballerina.stdlib
 version=1.0.4-SNAPSHOT
 ballerinaLangVersion=2201.12.0
+testngVersion=7.10.2
 
 ballerinaGradlePluginVersion=2.3.0
 ballerinaToOpenApiVersion=2.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.1.1-SNAPSHOT
+version=1.2.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 testngVersion=7.10.2
 

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -67,6 +67,10 @@ public final class McpServiceMethodHelper {
     private static final String MCP_PACKAGE_NAME = "mcp";
     private static final String SESSION_TYPE_NAME = "Session";
 
+    // HTTP Headers-related constants
+    private static final String HTTP_PACKAGE_NAME = "http";
+    private static final String HEADERS_TYPE_NAME = "Headers";
+
     private McpServiceMethodHelper() {}
 
     /**
@@ -128,7 +132,7 @@ public final class McpServiceMethodHelper {
      * @return           Record containing the invocation result or an error.
      */
     public static Object callToolForRemoteFunctions(Environment env, BObject mcpService, BMap<?, ?> params,
-                                                    Object session, BTypedesc typed) {
+                                                    Object session, BObject headers, BTypedesc typed) {
         BString toolName = (BString) params.get(fromString(NAME_FIELD_NAME));
 
         Optional<RemoteMethodType> method = getRemoteMethods(mcpService).stream()
@@ -141,7 +145,8 @@ public final class McpServiceMethodHelper {
         }
 
         Object argsOrError =
-                buildArgsForMethod(method.get(), (BMap<?, ?>) params.get(fromString(ARGUMENTS_FIELD_NAME)), session);
+                buildArgsForMethod(method.get(), (BMap<?, ?>) params.get(fromString(ARGUMENTS_FIELD_NAME)), session,
+                        headers);
 
         if (argsOrError instanceof BError) {
             return argsOrError;
@@ -203,7 +208,8 @@ public final class McpServiceMethodHelper {
         return tool;
     }
 
-    private static Object buildArgsForMethod(RemoteMethodType method, BMap<?, ?> arguments, Object session) {
+    private static Object buildArgsForMethod(RemoteMethodType method, BMap<?, ?> arguments, Object session,
+                                             Object headers) {
         List<Parameter> params = List.of(method.getParameters());
         Object[] args = new Object[params.size()];
         for (int i = 0; i < params.size(); i++) {
@@ -211,6 +217,8 @@ public final class McpServiceMethodHelper {
 
             if (isSessionParameter(param)) {
                 args[i] = session;
+            } else if (isHeadersParameter(param)) {
+                args[i] = headers;
             } else {
                 String paramName = param.name;
                 Object argValue = arguments == null ? null : arguments.get(fromString(paramName));
@@ -244,6 +252,13 @@ public final class McpServiceMethodHelper {
         return paramType.getPackage() != null
                 && MCP_PACKAGE_NAME.equals(paramType.getPackage().getName())
                 && SESSION_TYPE_NAME.equals(paramType.getName());
+    }
+
+    private static boolean isHeadersParameter(Parameter param) {
+        Type paramType = param.type;
+        return paramType.getPackage() != null
+                && HTTP_PACKAGE_NAME.equals(paramType.getPackage().getName())
+                && HEADERS_TYPE_NAME.equals(paramType.getName());
     }
 
     private static Object createCallToolResult(BTypedesc typed, Object result) {

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -114,6 +114,22 @@ public final class McpServiceMethodHelper {
     }
 
     /**
+     * Invoke the 'onCallTool' remote method of a Streamable HTTP advanced service, additionally
+     * passing the request's HTTP headers.
+     *
+     * @param env        The Ballerina runtime environment.
+     * @param mcpService The MCP service object.
+     * @param params     Parameters for the tool invocation.
+     * @param session    The session object (or null).
+     * @param headers    The HTTP headers of the request.
+     * @return           Result of remote method invocation.
+     */
+    public static Object invokeOnCallToolWithHeaders(Environment env, BObject mcpService, BMap<?, ?> params,
+                                                     Object session, BObject headers) {
+        return env.getRuntime().callMethod(mcpService, "onCallTool", null, params, session, headers);
+    }
+
+    /**
      * Lists tool metadata for remote functions in the given MCP service.
      *
      * @param mcpService The MCP service object.

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -74,6 +74,11 @@ public final class McpServiceMethodHelper {
     // MCP Session-related constants
     private static final String MCP_PACKAGE_NAME = "mcp";
     private static final String SESSION_TYPE_NAME = "Session";
+    private static final String CALL_TOOL_PARAMS_TYPE_NAME = "CallToolParams";
+
+    // Advanced service remote method names
+    private static final String ON_CALL_TOOL_METHOD = "onCallTool";
+    private static final String ON_LIST_TOOLS_METHOD = "onListTools";
 
     // HTTP Headers-related constants
     private static final String HTTP_PACKAGE_NAME = "http";
@@ -115,19 +120,61 @@ public final class McpServiceMethodHelper {
     }
 
     /**
-     * Invoke the 'onCallTool' remote method of a Streamable HTTP advanced service, additionally
-     * passing the underlying HTTP request.
+     * Invoke the 'onCallTool' remote method of a Streamable HTTP advanced service. The method's
+     * declared parameters are inspected and bound flexibly (CallToolParams, Session, http:Headers,
+     * http:Request, and '@http:Header' parameters), mirroring how basic service tools are bound.
      *
-     * @param env        The Ballerina runtime environment.
-     * @param mcpService The MCP service object.
-     * @param params     Parameters for the tool invocation.
-     * @param session    The session object (or null).
-     * @param request    The HTTP request.
-     * @return           Result of remote method invocation.
+     * @param env                    The Ballerina runtime environment.
+     * @param mcpService             The MCP service object.
+     * @param params                 The CallToolParams for the tool invocation.
+     * @param session                The session object (or null).
+     * @param headers                The HTTP headers of the request.
+     * @param request                The HTTP request.
+     * @param headerValues           Header values keyed by lower-cased name, for '@http:Header' binding.
+     * @param treatNilableAsOptional Whether a missing header binds a nilable '@http:Header' param to nil.
+     * @return                       Result of remote method invocation, or a binding error.
      */
-    public static Object invokeOnCallToolWithRequest(Environment env, BObject mcpService, BMap<?, ?> params,
-                                                     Object session, BObject request) {
-        return env.getRuntime().callMethod(mcpService, "onCallTool", null, params, session, request);
+    public static Object invokeAdvancedOnCallTool(Environment env, BObject mcpService, BMap<?, ?> params,
+                                                  Object session, BObject headers, BObject request,
+                                                  BMap<?, ?> headerValues, boolean treatNilableAsOptional) {
+        Optional<RemoteMethodType> method = getRemoteMethod(mcpService, ON_CALL_TOOL_METHOD);
+        if (method.isEmpty()) {
+            return ModuleUtils.createError("Remote method '" + ON_CALL_TOOL_METHOD + "' not found");
+        }
+        Object argsOrError = buildAdvancedArgs(method.get(), params, session, headers, request, headerValues,
+                treatNilableAsOptional);
+        if (argsOrError instanceof BError) {
+            return argsOrError;
+        }
+        return env.getRuntime().callMethod(mcpService, ON_CALL_TOOL_METHOD, null, (Object[]) argsOrError);
+    }
+
+    /**
+     * Invoke the 'onListTools' remote method of a Streamable HTTP advanced service. The method's
+     * declared parameters are inspected and bound flexibly (http:Headers, http:Request, and
+     * '@http:Header' parameters).
+     *
+     * @param env                    The Ballerina runtime environment.
+     * @param mcpService             The MCP service object.
+     * @param headers                The HTTP headers of the request.
+     * @param request                The HTTP request.
+     * @param headerValues           Header values keyed by lower-cased name, for '@http:Header' binding.
+     * @param treatNilableAsOptional Whether a missing header binds a nilable '@http:Header' param to nil.
+     * @return                       Result of remote method invocation, or a binding error.
+     */
+    public static Object invokeAdvancedOnListTools(Environment env, BObject mcpService, BObject headers,
+                                                   BObject request, BMap<?, ?> headerValues,
+                                                   boolean treatNilableAsOptional) {
+        Optional<RemoteMethodType> method = getRemoteMethod(mcpService, ON_LIST_TOOLS_METHOD);
+        if (method.isEmpty()) {
+            return ModuleUtils.createError("Remote method '" + ON_LIST_TOOLS_METHOD + "' not found");
+        }
+        Object argsOrError = buildAdvancedArgs(method.get(), null, null, headers, request, headerValues,
+                treatNilableAsOptional);
+        if (argsOrError instanceof BError) {
+            return argsOrError;
+        }
+        return env.getRuntime().callMethod(mcpService, ON_LIST_TOOLS_METHOD, null, (Object[]) argsOrError);
     }
 
     /**
@@ -233,6 +280,54 @@ public final class McpServiceMethodHelper {
         return List.of(serviceType.getRemoteMethods());
     }
 
+    private static Optional<RemoteMethodType> getRemoteMethod(BObject mcpService, String name) {
+        return getRemoteMethods(mcpService).stream()
+                .filter(rmt -> rmt.getName().equals(name))
+                .findFirst();
+    }
+
+    /**
+     * Builds the argument array for an advanced service remote method ('onCallTool'/'onListTools') by
+     * inspecting its declared parameters and injecting the matching value. 'callToolParams' is null
+     * for 'onListTools' (which has no CallToolParams parameter).
+     */
+    private static Object buildAdvancedArgs(RemoteMethodType method, Object callToolParams, Object session,
+                                            Object headers, Object request, BMap<?, ?> headerValues,
+                                            boolean treatNilableAsOptional) {
+        List<Parameter> params = List.of(method.getParameters());
+        Object[] args = new Object[params.size()];
+        for (int i = 0; i < params.size(); i++) {
+            Parameter param = params.get(i);
+            BMap<?, ?> headerAnnotation = getHeaderAnnotation(method, param.name);
+
+            if (isCallToolParamsParameter(param)) {
+                args[i] = callToolParams;
+            } else if (isSessionParameter(param)) {
+                args[i] = session;
+            } else if (isHeadersParameter(param)) {
+                args[i] = headers;
+            } else if (isRequestParameter(param)) {
+                args[i] = request;
+            } else if (headerAnnotation != null) {
+                Object headerValueOrError = bindHeaderParam(param.type, param.name, headerAnnotation, headerValues,
+                        treatNilableAsOptional);
+                if (headerValueOrError instanceof BError) {
+                    return headerValueOrError;
+                }
+                args[i] = headerValueOrError;
+            } else {
+                // The compiler plugin rejects any other parameter shape; guard defensively.
+                return ModuleUtils.createError("Unsupported parameter '" + param.name + "' in method '"
+                        + method.getName() + "'");
+            }
+        }
+        return args;
+    }
+
+    private static boolean isCallToolParamsParameter(Parameter param) {
+        return isParameterOfType(param, MCP_PACKAGE_NAME, CALL_TOOL_PARAMS_TYPE_NAME);
+    }
+
     private static BMap<BString, Object> createToolRecord(ArrayType toolsArrayType, RemoteMethodType remoteMethod,
                                                           BMap<?, ?> annotationValue) {
         RecordType toolRecordType = (RecordType) ((ReferenceType) toolsArrayType.getElementType()).getReferredType();
@@ -302,7 +397,17 @@ public final class McpServiceMethodHelper {
     }
 
     private static boolean isSessionParameter(Parameter param) {
-        return isParameterOfType(param, MCP_PACKAGE_NAME, SESSION_TYPE_NAME);
+        // Session is commonly declared nilable ('mcp:Session?'), so look through the union as well.
+        return isMcpSessionType(param.type);
+    }
+
+    private static boolean isMcpSessionType(Type type) {
+        if (type instanceof UnionType unionType) {
+            return unionType.getMemberTypes().stream().anyMatch(McpServiceMethodHelper::isMcpSessionType);
+        }
+        return type.getPackage() != null
+                && MCP_PACKAGE_NAME.equals(type.getPackage().getName())
+                && SESSION_TYPE_NAME.equals(type.getName());
     }
 
     private static boolean isHeadersParameter(Parameter param) {

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -78,6 +78,7 @@ public final class McpServiceMethodHelper {
     // HTTP Headers-related constants
     private static final String HTTP_PACKAGE_NAME = "http";
     private static final String HEADERS_TYPE_NAME = "Headers";
+    private static final String REQUEST_TYPE_NAME = "Request";
 
     // @http:Header annotation-related constants
     private static final String PARAM_ANNOT_PREFIX = "$param$.";
@@ -115,18 +116,18 @@ public final class McpServiceMethodHelper {
 
     /**
      * Invoke the 'onCallTool' remote method of a Streamable HTTP advanced service, additionally
-     * passing the request's HTTP headers.
+     * passing the underlying HTTP request.
      *
      * @param env        The Ballerina runtime environment.
      * @param mcpService The MCP service object.
      * @param params     Parameters for the tool invocation.
      * @param session    The session object (or null).
-     * @param headers    The HTTP headers of the request.
+     * @param request    The HTTP request.
      * @return           Result of remote method invocation.
      */
-    public static Object invokeOnCallToolWithHeaders(Environment env, BObject mcpService, BMap<?, ?> params,
-                                                     Object session, BObject headers) {
-        return env.getRuntime().callMethod(mcpService, "onCallTool", null, params, session, headers);
+    public static Object invokeOnCallToolWithRequest(Environment env, BObject mcpService, BMap<?, ?> params,
+                                                     Object session, BObject request) {
+        return env.getRuntime().callMethod(mcpService, "onCallTool", null, params, session, request);
     }
 
     /**
@@ -165,8 +166,9 @@ public final class McpServiceMethodHelper {
      * @return           Record containing the invocation result or an error.
      */
     public static Object callToolForRemoteFunctions(Environment env, BObject mcpService, BMap<?, ?> params,
-                                                    Object session, BObject headers, BMap<?, ?> headerValues,
-                                                    boolean treatNilableAsOptional, BTypedesc typed) {
+                                                    Object session, BObject headers, BObject request,
+                                                    BMap<?, ?> headerValues, boolean treatNilableAsOptional,
+                                                    BTypedesc typed) {
         BString toolName = (BString) params.get(fromString(NAME_FIELD_NAME));
 
         Optional<RemoteMethodType> method = getRemoteMethods(mcpService).stream()
@@ -180,7 +182,7 @@ public final class McpServiceMethodHelper {
 
         Object argsOrError =
                 buildArgsForMethod(method.get(), (BMap<?, ?>) params.get(fromString(ARGUMENTS_FIELD_NAME)), session,
-                        headers, headerValues, treatNilableAsOptional);
+                        headers, request, headerValues, treatNilableAsOptional);
 
         if (argsOrError instanceof BError) {
             return argsOrError;
@@ -243,7 +245,7 @@ public final class McpServiceMethodHelper {
     }
 
     private static Object buildArgsForMethod(RemoteMethodType method, BMap<?, ?> arguments, Object session,
-                                             Object headers, BMap<?, ?> headerValues,
+                                             Object headers, Object request, BMap<?, ?> headerValues,
                                              boolean treatNilableAsOptional) {
         List<Parameter> params = List.of(method.getParameters());
         Object[] args = new Object[params.size()];
@@ -255,6 +257,8 @@ public final class McpServiceMethodHelper {
                 args[i] = session;
             } else if (isHeadersParameter(param)) {
                 args[i] = headers;
+            } else if (isRequestParameter(param)) {
+                args[i] = request;
             } else if (headerAnnotation != null) {
                 Object headerValueOrError = bindHeaderParam(param.type, param.name, headerAnnotation, headerValues,
                         treatNilableAsOptional);
@@ -290,18 +294,23 @@ public final class McpServiceMethodHelper {
         return false;
     }
 
-    private static boolean isSessionParameter(Parameter param) {
+    private static boolean isParameterOfType(Parameter param, String moduleName, String typeName) {
         Type paramType = param.type;
         return paramType.getPackage() != null
-                && MCP_PACKAGE_NAME.equals(paramType.getPackage().getName())
-                && SESSION_TYPE_NAME.equals(paramType.getName());
+                && moduleName.equals(paramType.getPackage().getName())
+                && typeName.equals(paramType.getName());
+    }
+
+    private static boolean isSessionParameter(Parameter param) {
+        return isParameterOfType(param, MCP_PACKAGE_NAME, SESSION_TYPE_NAME);
     }
 
     private static boolean isHeadersParameter(Parameter param) {
-        Type paramType = param.type;
-        return paramType.getPackage() != null
-                && HTTP_PACKAGE_NAME.equals(paramType.getPackage().getName())
-                && HEADERS_TYPE_NAME.equals(paramType.getName());
+        return isParameterOfType(param, HTTP_PACKAGE_NAME, HEADERS_TYPE_NAME);
+    }
+
+    private static boolean isRequestParameter(Parameter param) {
+        return isParameterOfType(param, HTTP_PACKAGE_NAME, REQUEST_TYPE_NAME);
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/McpServiceMethodHelper.java
@@ -19,8 +19,11 @@
 package io.ballerina.stdlib.mcp;
 
 import io.ballerina.runtime.api.Environment;
+import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.flags.SymbolFlags;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.Parameter;
 import io.ballerina.runtime.api.types.RecordType;
 import io.ballerina.runtime.api.types.ReferenceType;
@@ -29,6 +32,8 @@ import io.ballerina.runtime.api.types.ServiceType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.TypeTags;
 import io.ballerina.runtime.api.types.UnionType;
+import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.utils.ValueUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
@@ -36,7 +41,10 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.ballerina.runtime.api.utils.StringUtils.fromString;
@@ -70,6 +78,15 @@ public final class McpServiceMethodHelper {
     // HTTP Headers-related constants
     private static final String HTTP_PACKAGE_NAME = "http";
     private static final String HEADERS_TYPE_NAME = "Headers";
+
+    // @http:Header annotation-related constants
+    private static final String PARAM_ANNOT_PREFIX = "$param$.";
+    private static final String FIELD_ANNOT_PREFIX = "$field$.";
+    private static final String HEADER_ANNOTATION_NAME = "Header";
+    private static final String ANNOTATION_NAME_FIELD = "name";
+    private static final String BALLERINA_ORG = "ballerina";
+    private static final String COLON = ":";
+    private static final String ORG_SEPARATOR = "/";
 
     private McpServiceMethodHelper() {}
 
@@ -132,7 +149,8 @@ public final class McpServiceMethodHelper {
      * @return           Record containing the invocation result or an error.
      */
     public static Object callToolForRemoteFunctions(Environment env, BObject mcpService, BMap<?, ?> params,
-                                                    Object session, BObject headers, BTypedesc typed) {
+                                                    Object session, BObject headers, BMap<?, ?> headerValues,
+                                                    boolean treatNilableAsOptional, BTypedesc typed) {
         BString toolName = (BString) params.get(fromString(NAME_FIELD_NAME));
 
         Optional<RemoteMethodType> method = getRemoteMethods(mcpService).stream()
@@ -146,7 +164,7 @@ public final class McpServiceMethodHelper {
 
         Object argsOrError =
                 buildArgsForMethod(method.get(), (BMap<?, ?>) params.get(fromString(ARGUMENTS_FIELD_NAME)), session,
-                        headers);
+                        headers, headerValues, treatNilableAsOptional);
 
         if (argsOrError instanceof BError) {
             return argsOrError;
@@ -209,16 +227,25 @@ public final class McpServiceMethodHelper {
     }
 
     private static Object buildArgsForMethod(RemoteMethodType method, BMap<?, ?> arguments, Object session,
-                                             Object headers) {
+                                             Object headers, BMap<?, ?> headerValues,
+                                             boolean treatNilableAsOptional) {
         List<Parameter> params = List.of(method.getParameters());
         Object[] args = new Object[params.size()];
         for (int i = 0; i < params.size(); i++) {
             Parameter param = params.get(i);
+            BMap<?, ?> headerAnnotation = getHeaderAnnotation(method, param.name);
 
             if (isSessionParameter(param)) {
                 args[i] = session;
             } else if (isHeadersParameter(param)) {
                 args[i] = headers;
+            } else if (headerAnnotation != null) {
+                Object headerValueOrError = bindHeaderParam(param.type, param.name, headerAnnotation, headerValues,
+                        treatNilableAsOptional);
+                if (headerValueOrError instanceof BError) {
+                    return headerValueOrError;
+                }
+                args[i] = headerValueOrError;
             } else {
                 String paramName = param.name;
                 Object argValue = arguments == null ? null : arguments.get(fromString(paramName));
@@ -259,6 +286,199 @@ public final class McpServiceMethodHelper {
         return paramType.getPackage() != null
                 && HTTP_PACKAGE_NAME.equals(paramType.getPackage().getName())
                 && HEADERS_TYPE_NAME.equals(paramType.getName());
+    }
+
+    /**
+     * Returns the value of the '@http:Header' annotation attached to the given parameter, or null if the parameter is
+     * not annotated with it.
+     */
+    private static BMap<?, ?> getHeaderAnnotation(RemoteMethodType method, String paramName) {
+        Object annotations = method.getAnnotation(fromString(PARAM_ANNOT_PREFIX + paramName));
+        if (!(annotations instanceof BMap<?, ?> annotationMap)) {
+            return null;
+        }
+        Object headerAnnotation = findHttpHeaderAnnotation(annotationMap);
+        if (headerAnnotation == null) {
+            return null;
+        }
+        return headerAnnotation instanceof BMap<?, ?> headerAnnotationMap
+                ? headerAnnotationMap : ValueCreator.createMapValue();
+    }
+
+    /**
+     * Finds the 'ballerina/http:<version>:Header' entry in an annotation map without depending on the exact module
+     * version segment of the key.
+     */
+    private static Object findHttpHeaderAnnotation(BMap<?, ?> annotationMap) {
+        String httpPrefix = BALLERINA_ORG + ORG_SEPARATOR + HTTP_PACKAGE_NAME + COLON;
+        for (Object key : annotationMap.getKeys()) {
+            String keyName = key.toString();
+            if (keyName.startsWith(httpPrefix) && keyName.endsWith(COLON + HEADER_ANNOTATION_NAME)) {
+                return annotationMap.get(key);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Binds the value of an HTTP header (or a record of headers) to a '@http:Header' annotated parameter, mirroring the
+     * semantics of '@http:Header' on http resources.
+     */
+    private static Object bindHeaderParam(Type paramType, String paramName, BMap<?, ?> annotation,
+                                          BMap<?, ?> headerValues, boolean treatNilableAsOptional) {
+        boolean readonlyParam = TypeUtils.getReferredType(paramType).getTag() == TypeTags.INTERSECTION_TAG;
+        Type effectiveType = TypeUtils.getImpliedType(paramType);
+        boolean nilable = false;
+        if (effectiveType instanceof UnionType unionType) {
+            List<Type> nonNilMembers = new ArrayList<>();
+            for (Type member : unionType.getMemberTypes()) {
+                if (member.getTag() == TypeTags.NULL_TAG) {
+                    nilable = true;
+                } else {
+                    if (TypeUtils.getReferredType(member).getTag() == TypeTags.INTERSECTION_TAG) {
+                        readonlyParam = true;
+                    }
+                    nonNilMembers.add(TypeUtils.getImpliedType(member));
+                }
+            }
+            // A single non-nil member is bound directly; multiple members (enums and other
+            // finite string unions) keep the union and rely on value conversion to validate
+            if (nonNilMembers.size() == 1) {
+                effectiveType = nonNilMembers.getFirst();
+            }
+        }
+
+        if (effectiveType instanceof RecordType recordType) {
+            return bindHeaderRecord(recordType, nilable, headerValues, treatNilableAsOptional, readonlyParam);
+        }
+
+        Object nameValue = annotation.get(fromString(ANNOTATION_NAME_FIELD));
+        String headerName = nameValue instanceof BString headerNameValue
+                ? headerNameValue.getValue() : paramName;
+        return bindSingleHeader(effectiveType, headerName, nilable, headerValues, treatNilableAsOptional,
+                readonlyParam);
+    }
+
+    private static Object bindSingleHeader(Type type, String headerName, boolean nilable, BMap<?, ?> headerValues,
+                                           boolean treatNilableAsOptional, boolean readonlyValue) {
+        Object values = headerValues.get(fromString(headerName.toLowerCase(Locale.ROOT)));
+        if (values == null || ((BArray) values).getLength() == 0) {
+            if (nilable && treatNilableAsOptional) {
+                return null;
+            }
+            return ModuleUtils.createParameterBindingError("no header value found for '" + headerName + "'");
+        }
+        BArray headerValueArray = (BArray) values;
+        try {
+            if (TypeUtils.getImpliedType(type) instanceof ArrayType arrayType) {
+                // Build into a mutable array (the declared one may be readonly) and freeze after
+                Type elementType = arrayType.getElementType();
+                BArray boundValues = ValueCreator.createArrayValue(
+                        TypeCreator.createArrayType(TypeUtils.getImpliedType(elementType)));
+                for (int i = 0; i < headerValueArray.getLength(); i++) {
+                    boundValues.append(convertHeaderValue(elementType,
+                            headerValueArray.getBString(i).getValue()));
+                }
+                if (readonlyValue) {
+                    boundValues.freezeDirect();
+                }
+                return boundValues;
+            }
+            return convertHeaderValue(type, headerValueArray.getBString(0).getValue());
+        } catch (NumberFormatException | BError e) {
+            return ModuleUtils.createParameterBindingError(
+                    "header binding failed for parameter '" + headerName + "'");
+        }
+    }
+
+    private static Object convertHeaderValue(Type targetType, String value) {
+        int typeTag = TypeUtils.getImpliedType(targetType).getTag();
+        return switch (typeTag) {
+            case TypeTags.STRING_TAG -> fromString(value);
+            case TypeTags.INT_TAG -> Long.parseLong(value);
+            case TypeTags.FLOAT_TAG -> Double.parseDouble(value);
+            case TypeTags.DECIMAL_TAG -> ValueCreator.createDecimalValue(value);
+            case TypeTags.BOOLEAN_TAG -> Boolean.parseBoolean(value);
+            // Finite types, enums, and other string-constant unions: conversion both casts
+            // and validates that the header value is a member of the type
+            default -> ValueUtils.convert(fromString(value), targetType);
+        };
+    }
+
+    private static Object bindHeaderRecord(RecordType recordType, boolean nilableRecord, BMap<?, ?> headerValues,
+                                           boolean treatNilableAsOptional, boolean readonlyRecord) {
+        // For readonly records, populate a plain mutable map and convert to the readonly
+        // record type at the end (the readonly record type cannot be mutated field by field)
+        BMap<BString, Object> recordValue = readonlyRecord
+                ? ValueCreator.createMapValue()
+                : ValueCreator.createRecordValue(recordType);
+        BMap<BString, Object> recordAnnotations = recordType.getAnnotations();
+        for (Map.Entry<String, Field> entry : recordType.getFields().entrySet()) {
+            String fieldName = entry.getKey();
+            Field field = entry.getValue();
+            boolean optionalField = SymbolFlags.isFlagOn(field.getFlags(), SymbolFlags.OPTIONAL);
+
+            // A field-level '@http:Header {name: ...}' annotation overrides the header name
+            String headerName = fieldName;
+            if (recordAnnotations != null) {
+                Object fieldAnnotations = recordAnnotations.get(fromString(FIELD_ANNOT_PREFIX + fieldName));
+                if (fieldAnnotations instanceof BMap<?, ?> fieldAnnotationMap
+                        && findHttpHeaderAnnotation(fieldAnnotationMap) instanceof BMap<?, ?> headerAnnotationMap) {
+                    Object nameValue = headerAnnotationMap.get(fromString(ANNOTATION_NAME_FIELD));
+                    if (nameValue instanceof BString headerNameValue) {
+                        headerName = headerNameValue.getValue();
+                    }
+                }
+            }
+
+            Type fieldType = TypeUtils.getImpliedType(field.getFieldType());
+            boolean nilable = false;
+            if (fieldType instanceof UnionType unionType) {
+                List<Type> nonNilMembers = new ArrayList<>();
+                for (Type member : unionType.getMemberTypes()) {
+                    if (member.getTag() == TypeTags.NULL_TAG) {
+                        nilable = true;
+                    } else {
+                        nonNilMembers.add(TypeUtils.getImpliedType(member));
+                    }
+                }
+                if (nonNilMembers.size() == 1) {
+                    fieldType = nonNilMembers.get(0);
+                }
+            }
+
+            Object values = headerValues.get(fromString(headerName.toLowerCase(Locale.ROOT)));
+            if (values == null || ((BArray) values).getLength() == 0) {
+                if (optionalField) {
+                    continue;
+                }
+                if (nilable && treatNilableAsOptional) {
+                    recordValue.put(fromString(fieldName), null);
+                    continue;
+                }
+                // Consistent with http: a nilable header record binds to nil when a
+                // required header is missing, instead of failing the request
+                if (nilableRecord && treatNilableAsOptional) {
+                    return null;
+                }
+                return ModuleUtils.createParameterBindingError("no header value found for '" + headerName + "'");
+            }
+
+            Object boundValue = bindSingleHeader(fieldType, headerName, nilable, headerValues,
+                    treatNilableAsOptional, false);
+            if (boundValue instanceof BError) {
+                return boundValue;
+            }
+            recordValue.put(fromString(fieldName), boundValue);
+        }
+        if (readonlyRecord) {
+            try {
+                return ValueUtils.convert(recordValue, recordType);
+            } catch (BError e) {
+                return ModuleUtils.createParameterBindingError("header binding failed for record of headers");
+            }
+        }
+        return recordValue;
     }
 
     private static Object createCallToolResult(BTypedesc typed, Object result) {

--- a/native/src/main/java/io/ballerina/stdlib/mcp/ModuleUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/mcp/ModuleUtils.java
@@ -44,4 +44,8 @@ public final class ModuleUtils {
     public static BError createError(String errorMessage) {
         return ErrorCreator.createError(fromString(errorMessage));
     }
+
+    public static BError createParameterBindingError(String errorMessage) {
+        return ErrorCreator.createError(module, "ParameterBindingError", fromString(errorMessage), null, null);
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,12 +38,14 @@ include ':checkstyle'
 include ':mcp-ballerina'
 include ':mcp-native'
 include ':mcp-compiler-plugin'
+include ':mcp-compiler-plugin-tests'
 include ':mcp-ballerina-tests'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':mcp-ballerina').projectDir = file('ballerina')
 project(':mcp-native').projectDir = file('native')
 project(':mcp-compiler-plugin').projectDir = file('compiler-plugin')
+project(':mcp-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':mcp-ballerina-tests').projectDir = file('ballerina-tests')
 
 gradleEnterprise {


### PR DESCRIPTION
## Purpose

Enable MCP tools to access transport-specific request information (HTTP headers, the raw request) while keeping `mcp:Service` transport-agnostic.

This introduces transport-specific service types and moves all HTTP-specific configuration and request access onto them:

- **Transport-specific service types** — `mcp:StreamableHttpService` and `mcp:StreamableHttpAdvancedService`, alongside the transport-agnostic `mcp:Service`/`mcp:AdvancedService`. HTTP request access is only available on the Streamable HTTP types; the type system enforces listener compatibility.
- **Listener rename** — `mcp:Listener` → `mcp:StreamableHttpListener` (deprecated alias retained for backward compatibility).
- **Config relocation** — HTTP-specific config (`httpConfig`, `sessionMode`) moved onto `@mcp:StreamableHttpServiceConfig`; the corresponding `@mcp:ServiceConfig` fields are deprecated but still honored.
- **HTTP header binding** — tool `remote` functions on `mcp:StreamableHttpService` may bind `@http:Header` parameters (full type parity with `ballerina/http`) and a raw `http:Headers` parameter.
- **HTTP request binding** — tool `remote` functions may bind an `http:Request` parameter; `StreamableHttpAdvancedService.onCallTool` receives the `http:Request` directly.

The compiler plugin rejects transport-specific parameters on the transport-agnostic `mcp:Service` (MCP_107) and validates parameter shapes.

Supersedes #52 (closed when the branch was renamed).

Part of https://github.com/ballerina-platform/ballerina-library/issues/8808

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds transport-specific Streamable HTTP MCP service types and compiler/runtime support so MCP tool handlers can access HTTP request context (headers and the raw request) while keeping the core `mcp:Service` transport-agnostic.

### Key changes
- **New Streamable HTTP service markers**
  - Introduces `mcp:StreamableHttpService` and `mcp:StreamableHttpAdvancedService` for HTTP-aware tool callback shapes.
- **Listener naming and compatibility**
  - Renames `mcp:Listener` to `mcp:StreamableHttpListener` and keeps `mcp:Listener` as a deprecated compatibility wrapper.
- **Streamable HTTP configuration and precedence**
  - Adds `@mcp:StreamableHttpServiceConfig` and centralizes transport-specific options (including `httpConfig`/`sessionMode`).
  - Preserves older/deprecated `@mcp:ServiceConfig` fields for compatibility, with transport config taking precedence.
- **HTTP header/raw request binding in tools**
  - Enables tool parameter binding for `@http:Header`, `http:Headers`, and (where supported) `http:Request`.
  - Ensures transport-injected parameters are excluded from generated tool input schemas.
- **Advanced callback support**
  - Extends `StreamableHttpAdvancedService.onCallTool` to receive direct `http:Request`/header information (in addition to bound header values).
- **Improved validation and error mapping**
  - Adds `ParameterBindingError` for parameter binding failures and maps such failures to JSON-RPC `invalid params`.
  - Tightens compiler validation so transport-specific HTTP parameters are only allowed with Streamable HTTP services, including shape/uniqueness rules for `http:Headers`/`http:Request` and correct advanced service callback signatures.
  - Updates dispatcher/native invocation flow to forward headers and raw `http:Request` into the tool handlers.

### Tests, fixtures, and examples
- Adds integration tests for:
  - header binding (including typed headers, enums, readonly arrays, record binding, and schema exclusion),
  - strict nilable-header handling via `treatNilableAsOptional`,
  - transport config precedence and listener naming,
  - advanced service list/call behavior with header/request access.
- Adds compiler-plugin tests/fixtures covering valid and invalid Streamable HTTP service/tool parameter shapes and advanced-service callback validation (plus a TestNG suite).
- Updates example MCP servers to use `mcp:StreamableHttpListener` and `@mcp:StreamableHttpServiceConfig`.

### Dependency and build updates
- Updates MCP/Ballerina dependency versions used by the test suites.
- Bumps project snapshot versions and adds/adjusts Gradle test wiring (including compiler-plugin test execution).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->