### PR TITLE
Restore Request.params type to RequestParams

### DIFF
--- a/ballerina/dispatcher_service.bal
+++ b/ballerina/dispatcher_service.bal
@@ -152,8 +152,8 @@ isolated function getDispatcherService(http:HttpServiceConfig httpServiceConfig)
 
         private isolated function handleInitializeRequest(JsonRpcRequest jsonRpcRequest, http:Headers headers)
             returns http:BadRequest|http:Ok|Error {
-            RequestId? id = jsonRpcRequest.id;
-            InitializeRequest|error initRequest = jsonRpcRequest.cloneWithType();
+            JsonRpcRequest {jsonrpc: _, id, ...request} = jsonRpcRequest;
+            InitializeRequest|error initRequest = request.cloneWithType();
             if initRequest is error {
                 return <http:BadRequest>{
                     body: createJsonRpcError(INVALID_REQUEST,

--- a/ballerina/streamable_http_client.bal
+++ b/ballerina/streamable_http_client.bal
@@ -52,8 +52,7 @@ public distinct isolated client class StreamableHttpClient {
         }
 
         // Prepare and send the initialization request.
-        Request initRequest = {
-            method: REQUEST_INITIALIZE,
+        InitializeRequest initRequest = {
             params: {
                 protocolVersion: LATEST_PROTOCOL_VERSION,
                 capabilities: capabilities,

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -80,7 +80,7 @@ public type Request record {|
     # The method name for the request
     string method;
     # Optional parameters for the request
-    map<anydata> params?;
+    RequestParams params?;
 |};
 
 # Represents a notification.
@@ -166,7 +166,7 @@ public type JsonRpcError record {|
 
 # This request is sent from the client to the server when it first connects, asking it to begin initialization.
 type InitializeRequest record {|
-    *JsonRpcRequest;
+    *Request;
     # Method name for the request
     REQUEST_INITIALIZE method = REQUEST_INITIALIZE;
     # Parameters for the initialize request


### PR DESCRIPTION
## Purpose
PR #47 widened the public Request.params field from RequestParams to map<anydata> while rebasing InitializeRequest onto JsonRpcRequest. That made InitializeRequest unusable for client-side construction (mandatory id does not exist before sending), forcing the client onto the bare Request type, whose record typing rejects identifier keys for undeclared params fields - hence the widening. This broke source compatibility for 1.0.x consumers dot-accessing params?._meta.

Restore the 1.0.3 pattern, keeping all 2025-11-25 functionality:
- Request.params is RequestParams again. As an open record it accepts arbitrary anydata rest fields, so it is wire-equivalent to map<anydata> ({ [key: string]: any } in the spec schema) while also declaring _meta as the four earlier protocol revisions specify.
- InitializeRequest (module-private) is based on *Request again, with declared params fields, so the client constructs it with identifier keys and passes it to sendRequestMessage as a Request subtype.
- The dispatcher splits the JSON-RPC envelope off before cloning into InitializeRequest, as before.

Note that the change in the linked PR is unreleased.