### PR TITLE
Relax meta parameter placement

### DIFF
--- a/ballerina-tests/mcp-ballerina-tests/tests/meta_tests.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/meta_tests.bal
@@ -29,13 +29,14 @@ isolated service mcp:Service /mcp on metaListener {
     #
     # + name - The name to greet
     # + meta - Optional request metadata injected by the framework
+    # + greeting - Greeting to prepend to the name
     # + return - A greeting message that reflects whether metadata was received
-    isolated remote function greetWithMeta(string name, mcp:Meta? meta) returns string {
+    isolated remote function greetWithMeta(string name, mcp:Meta? meta, string greeting) returns string {
         if meta is mcp:Meta {
             anydata traceId = meta["traceId"];
-            return string `Hello, ${name}! trace=${traceId.toString()}`;
+            return string `${greeting}, ${name}! trace=${traceId.toString()}`;
         }
-        return string `Hello, ${name}! no-meta`;
+        return string `${greeting}, ${name}! no-meta`;
     }
 }
 
@@ -54,6 +55,8 @@ function testMetaToolSchemaExcludesMetaParam() returns error? {
     map<record {}> properties = check inputSchema.properties.ensureType();
     test:assertTrue(properties.hasKey("name"),
         msg = "Schema must include the 'name' data parameter");
+    test:assertTrue(properties.hasKey("greeting"),
+        msg = "Schema must include data parameters declared after mcp:Meta");
     test:assertFalse(properties.hasKey("meta"),
         msg = "The injected mcp:Meta parameter must not appear in the tool input schema");
 }
@@ -62,7 +65,7 @@ function testMetaToolSchemaExcludesMetaParam() returns error? {
 function testMetaReceivedOnServer() returns error? {
     mcp:CallToolResult result = check metaClient->callTool({
         name: "greetWithMeta",
-        arguments: {"name": "World"},
+        arguments: {"name": "World", "greeting": "Hello"},
         _meta: {"traceId": "trace-xyz"}
     });
 
@@ -81,7 +84,7 @@ function testMetaReceivedOnServer() returns error? {
 function testMetaIsNilWhenClientOmitsIt() returns error? {
     mcp:CallToolResult result = check metaClient->callTool({
         name: "greetWithMeta",
-        arguments: {"name": "World"}
+        arguments: {"name": "World", "greeting": "Hello"}
     });
 
     mcp:TextContent textContent = check result.content[0].ensureType();

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/mcp/plugin/CompilerPluginTest.java
@@ -212,4 +212,12 @@ public class CompilerPluginTest {
         Assert.assertFalse(diagnostic.message().contains("mcp:Session"),
                 "onListTools supported-types message must not list 'mcp:Session': " + diagnostic.message());
     }
+
+    @Test
+    public void testMetaParameterCanAppearBeforeDataParameters() {
+        DiagnosticResult diagnosticResult = compile("sample_package_18");
+        Assert.assertEquals(errorCount(diagnosticResult), 0,
+                "an optional mcp:Meta parameter must be accepted outside the final position: "
+                        + diagnosticResult.errors().toString());
+    }
 }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_18/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_18/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "mcp_test"
+name = "sample_18"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_18/service.bal
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/sample_package_18/service.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/mcp;
+
+@mcp:ServiceConfig {
+    info: {name: "sample-18", version: "1.0.0"}
+}
+service mcp:Service /mcp on new mcp:StreamableHttpListener(9318) {
+
+    @mcp:Tool {description: "metadata can be injected between tool arguments"}
+    remote function metaInMiddle(string name, mcp:Meta? meta, string greeting) returns string {
+        if meta is mcp:Meta {
+            return string `${greeting}, ${name}!`;
+        }
+        return string `${greeting}, ${name}! no-meta`;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -82,7 +82,7 @@ public class Utils {
 
     // Human-readable lists of supported parameter types, used in the INVALID_PARAMETER_TYPE diagnostic.
     public static final String BASIC_TOOL_SUPPORTED_PARAM_TYPES =
-            "'anydata' tool parameters, a first 'mcp:Session' parameter, a last 'mcp:Meta' parameter, "
+            "'anydata' tool parameters, a first 'mcp:Session' parameter, an optional 'mcp:Meta' parameter, "
                     + "an 'http:Headers' parameter, an 'http:Request' parameter, or '@http:Header' parameters";
     public static final String ADVANCED_SUPPORTED_PARAM_TYPES =
             "'mcp:CallToolParams', 'mcp:Session', 'http:Headers', 'http:Request', or an '@http:Header' parameter";
@@ -329,18 +329,9 @@ public class Utils {
             } else if (isMetaParam) {
                 if (hasMetaParam) {
                     Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
-                            CompilationDiagnostic.META_PARAM_MUST_BE_LAST,
+                            CompilationDiagnostic.DUPLICATE_PARAMETER,
                             parameterSymbol.getLocation().orElse(alternativeLocation),
-                            functionName, parameterName);
-                    context.reportDiagnostic(diagnostic);
-                    return false;
-                }
-
-                if (i != parameterSymbolList.size() - 1) {
-                    Diagnostic diagnostic = CompilationDiagnostic.getDiagnostic(
-                            CompilationDiagnostic.META_PARAM_MUST_BE_LAST,
-                            parameterSymbol.getLocation().orElse(alternativeLocation),
-                            functionName, parameterName);
+                            functionName, parameterName, MCP_PACKAGE_NAME + ":" + META_TYPE_NAME);
                     context.reportDiagnostic(diagnostic);
                     return false;
                 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/diagnostics/CompilationDiagnostic.java
@@ -34,6 +34,7 @@ public enum CompilationDiagnostic {
     INVALID_PARAMETER_TYPE(DiagnosticMessage.ERROR_102, DiagnosticCode.MCP_102, ERROR),
     SESSION_PARAM_MUST_BE_FIRST(DiagnosticMessage.ERROR_103, DiagnosticCode.MCP_103, ERROR),
     SESSION_PARAM_NOT_ALLOWED_IN_STATELESS_MODE(DiagnosticMessage.ERROR_104, DiagnosticCode.MCP_104, ERROR),
+    // Retained for compatibility; Meta parameters are no longer required to be last.
     META_PARAM_MUST_BE_LAST(DiagnosticMessage.ERROR_105, DiagnosticCode.MCP_105, ERROR),
     META_PARAM_MUST_BE_OPTIONAL(DiagnosticMessage.ERROR_106, DiagnosticCode.MCP_106, ERROR),
     DUPLICATE_PARAMETER(DiagnosticMessage.ERROR_107, DiagnosticCode.MCP_107, ERROR),


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-library/issues/8972
The `mcp:Meta` parameter in MCP service types is currently required to be the last parameter in a remote function signature. Since this restriction is unnecessary and uncommon, this PR relaxes it. The implementation already identifies the parameter by its type.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Allow `mcp:Meta` parameters in any position within MCP service remote function signatures.
- Update validation and diagnostics to identify metadata parameters by type and detect duplicates.
- Add compiler and integration tests covering metadata parameters placed before regular parameters.
- Refresh Ballerina dependency and native test package versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->