### PR TITLE
Fix source modifier dropping methods from services co-located with mcp tools

### DIFF
--- a/ballerina-tests/mcp-ballerina-tests/tests/advanced_service_shared_document_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/advanced_service_shared_document_test.bal
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression coverage: the source modifier rewrites every service declaration in a document that
+// contains tools, and used to re-emit only registered '@mcp:Tool' methods -- silently dropping an
+// advanced service's 'onListTools'/'onCallTool' when it shared a document with a tool-bearing basic
+// service. Because 'mcp:StreamableHttpAdvancedService' is an empty object type (its method shapes
+// are validated by the compiler plugin in the analysis phase, before the modifier runs), the drop
+// produced no diagnostic and only failed at runtime.
+//
+// These two services MUST stay in the same document for this test to be meaningful.
+
+import ballerina/http;
+import ballerina/mcp;
+import ballerina/test;
+
+// The tool-bearing basic service. Its presence is what makes the modifier rewrite this document.
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "shared-doc-basic", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:StreamableHttpService /sharedBasic on new mcp:StreamableHttpListener(8774) {
+    isolated remote function greet(string name) returns string => "hello " + name;
+}
+
+// The advanced service sharing the document above.
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "shared-doc-advanced", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:StreamableHttpAdvancedService /sharedAdvanced on new mcp:StreamableHttpListener(8775) {
+    isolated remote function onListTools() returns mcp:ListToolsResult|mcp:ServerError {
+        return {
+            tools: [{name: "sharedDocTool", description: "declared by onListTools", inputSchema: {'type: "object"}}]
+        };
+    }
+
+    isolated remote function onCallTool(mcp:CallToolParams params, mcp:Session? session)
+            returns mcp:CallToolResult|mcp:ServerError {
+        return {content: [{'type: "text", text: "shared-doc-ok"}]};
+    }
+}
+
+final http:Client sharedDocClient = check new ("http://localhost:8775");
+final http:Client sharedDocBasicClient = check new ("http://localhost:8774");
+
+@test:Config
+function testAdvancedServiceOnListToolsSurvivesSharedDocument() returns error? {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/list", params: {}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check sharedDocClient->post("/sharedAdvanced", request);
+    json result = check response.getJsonPayload();
+    json[] tools = check (check result.result.tools).ensureType();
+    test:assertEquals(tools.length(), 1);
+    test:assertEquals(check tools[0].name, "sharedDocTool");
+}
+
+@test:Config
+function testAdvancedServiceOnCallToolSurvivesSharedDocument() returns error? {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 2, method: "tools/call",
+        params: {name: "sharedDocTool", arguments: {}}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check sharedDocClient->post("/sharedAdvanced", request);
+    json result = check response.getJsonPayload();
+    test:assertEquals(check getRawTextResult(result), "shared-doc-ok");
+}
+
+@test:Config
+function testBasicServiceToolStillWorksInSharedDocument() returns error? {
+    // The co-located basic service must keep working: the modifier still has to annotate its tools.
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 3, method: "tools/list", params: {}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check sharedDocBasicClient->post("/sharedBasic", request);
+    json result = check response.getJsonPayload();
+    json[] tools = check (check result.result.tools).ensureType();
+    test:assertEquals(tools.length(), 1);
+    test:assertEquals(check tools[0].name, "greet");
+}

--- a/ballerina-tests/mcp-ballerina-tests/tests/advanced_service_shared_document_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/advanced_service_shared_document_test.bal
@@ -92,3 +92,15 @@ function testBasicServiceToolStillWorksInSharedDocument() returns error? {
     test:assertEquals(tools.length(), 1);
     test:assertEquals(check tools[0].name, "greet");
 }
+
+@test:Config
+function testBasicServiceToolInvocationStillWorksInSharedDocument() returns error? {
+    // Listing the tool is not enough: the rewritten method must remain callable.
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 4, method: "tools/call",
+        params: {name: "greet", arguments: {name: "shared"}}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check sharedDocBasicClient->post("/sharedBasic", request);
+    json result = check response.getJsonPayload();
+    test:assertEquals(check getRawTextResult(result), "hello shared");
+}

--- a/ballerina-tests/mcp-ballerina-tests/tests/non_mcp_service_shared_document_test.bal
+++ b/ballerina-tests/mcp-ballerina-tests/tests/non_mcp_service_shared_document_test.bal
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Regression coverage: the source modifier used to rewrite EVERY service declaration in a document
+// that contains mcp tools -- including services that have nothing to do with mcp. A plain
+// 'http:Service' sharing a document with an mcp tool had its non-resource methods dropped, so this
+// document failed to compile with "undefined method 'helper'". Resource methods survived only
+// incidentally, because their syntax kind is not OBJECT_METHOD_DEFINITION.
+//
+// The modifier now skips any service that is not an mcp basic service. The plain http:Service below
+// MUST stay in the same document as the mcp service for this test to be meaningful.
+
+import ballerina/http;
+import ballerina/mcp;
+import ballerina/test;
+
+// A plain http:Service -- not an mcp service at all.
+service /plain on new http:Listener(8776) {
+    resource function get ping() returns string => self.buildPong();
+
+    resource function post echo(@http:Payload string body) returns string => self.decorate(body);
+
+    // Non-resource object methods: these are what used to be dropped.
+    function buildPong() returns string => "pong";
+
+    function decorate(string body) returns string => "echo:" + body;
+}
+
+// The mcp tool-bearing service that causes this document to be rewritten.
+@mcp:StreamableHttpServiceConfig {
+    info: {name: "mixed-doc", version: "1.0.0"},
+    sessionMode: mcp:STATELESS
+}
+isolated service mcp:StreamableHttpService /mixedMcp on new mcp:StreamableHttpListener(8777) {
+    isolated remote function greet(string name) returns string => "hello " + name;
+}
+
+final http:Client plainClient = check new ("http://localhost:8776");
+final http:Client mixedMcpClient = check new ("http://localhost:8777");
+
+@test:Config
+function testPlainHttpServiceMethodsSurviveSharedDocument() returns error? {
+    // Both resource methods delegate to non-resource helpers. If the helpers were dropped this
+    // document would not compile at all; if they were mangled these calls would fail.
+    string ping = check plainClient->get("/plain/ping");
+    test:assertEquals(ping, "pong");
+
+    string echo = check plainClient->post("/plain/echo", "hi");
+    test:assertEquals(echo, "echo:hi");
+}
+
+@test:Config
+function testMcpToolStillWorksAlongsidePlainHttpService() returns error? {
+    // The mcp service in the same document must still be rewritten correctly.
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 1, method: "tools/call",
+        params: {name: "greet", arguments: {name: "mixed"}}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check mixedMcpClient->post("/mixedMcp", request);
+    json result = check response.getJsonPayload();
+    test:assertEquals(check getRawTextResult(result), "hello mixed");
+}
+
+@test:Config
+function testMcpToolIsListedAlongsidePlainHttpService() returns error? {
+    http:Request request = new;
+    request.setJsonPayload({jsonrpc: "2.0", id: 2, method: "tools/list", params: {}});
+    request.setHeader("Accept", "application/json, text/event-stream");
+    http:Response response = check mixedMcpClient->post("/mixedMcp", request);
+    json result = check response.getJsonPayload();
+    json[] tools = check (check result.result.tools).ensureType();
+    test:assertEquals(tools.length(), 1);
+    test:assertEquals(check tools[0].name, "greet");
+}

--- a/changelog.md
+++ b/changelog.md
@@ -6,4 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [Transport-specific MCP service types with access to HTTP headers and the raw request](https://github.com/ballerina-platform/ballerina-library/issues/8808)
+
+### Changed
+- [Relaxed the requirement for the `mcp:Meta?` parameter of a tool function to be declared last](https://github.com/ballerina-platform/ballerina-library/issues/8972)
+
+### Deprecated
+- The `mcp:Listener` class, in favour of `mcp:StreamableHttpListener`.
+- The `httpConfig` and `sessionMode` fields of the `@mcp:ServiceConfig` annotation, in favour of the corresponding fields of `@mcp:StreamableHttpServiceConfig`.
+
+### Fixed
+- [Service methods are dropped when a service shares a document with an MCP tool](https://github.com/ballerina-platform/ballerina-library/issues/8971)
+
+## [1.1.0] - 2026-07-02
+
+### Added
 - Partial support for MCP protocol version `2025-11-25`, with backward compatibility for `2025-06-18`, `2025-03-26`, and `2024-11-05`. Task-augmented requests introduced in `2025-11-25` are not yet supported.

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/McpSourceModifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/McpSourceModifier.java
@@ -168,6 +168,9 @@ public class McpSourceModifier implements ModifierTask<SourceModifierContext> {
             FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) member;
             AnnotationNode modifiedAnnotationNode = modifiedAnnotations.get(functionDefinitionNode);
             if (modifiedAnnotationNode == null) {
+                // Not a registered tool (e.g. an advanced service's 'onListTools'/'onCallTool'
+                // sharing this document). Re-emit it unchanged rather than dropping it.
+                modifiedMembers.add(member);
                 continue;
             }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/McpSourceModifier.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/McpSourceModifier.java
@@ -145,7 +145,7 @@ public class McpSourceModifier implements ModifierTask<SourceModifierContext> {
             ModuleMemberDeclarationNode member,
             Map<FunctionDefinitionNode, AnnotationNode> modifiedAnnotations) {
 
-        if (member.kind() == SERVICE_DECLARATION) {
+        if (member.kind() == SERVICE_DECLARATION && Utils.isMcpBasicService(semanticModel, member)) {
             return modifyServiceDeclaration(semanticModel, (ServiceDeclarationNode) member, modifiedAnnotations);
         }
         return member;
@@ -168,8 +168,6 @@ public class McpSourceModifier implements ModifierTask<SourceModifierContext> {
             FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) member;
             AnnotationNode modifiedAnnotationNode = modifiedAnnotations.get(functionDefinitionNode);
             if (modifiedAnnotationNode == null) {
-                // Not a registered tool (e.g. an advanced service's 'onListTools'/'onCallTool'
-                // sharing this document). Re-emit it unchanged rather than dropping it.
                 modifiedMembers.add(member);
                 continue;
             }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/mcp/plugin/Utils.java
@@ -42,6 +42,7 @@ import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.MappingFieldNode;
 import io.ballerina.compiler.syntax.tree.MetadataNode;
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeList;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
@@ -184,13 +185,23 @@ public class Utils {
 
     public static boolean isMcpServiceFunction(SemanticModel semanticModel,
                                                FunctionDefinitionNode functionDefinitionNode) {
-        Optional<Symbol> parentSymbol = semanticModel.symbol(functionDefinitionNode.parent());
+        return isMcpBasicService(semanticModel, functionDefinitionNode.parent());
+    }
 
-        if (parentSymbol.isEmpty() || parentSymbol.get().kind() != SymbolKind.SERVICE_DECLARATION) {
+    /**
+     * Returns whether the given node is an `mcp:Service` or `mcp:StreamableHttpService` declaration attached to a
+     * listener from the mcp module. These are the only services whose tool methods the source modifier may rewrite;
+     * every other service declaration (including advanced mcp services and unrelated services such as `http:Service`)
+     * must be left untouched.
+     */
+    public static boolean isMcpBasicService(SemanticModel semanticModel, Node serviceNode) {
+        Optional<Symbol> serviceDeclSymbol = semanticModel.symbol(serviceNode);
+
+        if (serviceDeclSymbol.isEmpty() || serviceDeclSymbol.get().kind() != SymbolKind.SERVICE_DECLARATION) {
             return false;
         }
 
-        ServiceDeclarationSymbol serviceSymbol = (ServiceDeclarationSymbol) parentSymbol.get();
+        ServiceDeclarationSymbol serviceSymbol = (ServiceDeclarationSymbol) serviceDeclSymbol.get();
 
         boolean isFromMcpModule = serviceSymbol.listenerTypes().stream()
                 .anyMatch(Utils::isListenerFromMcpModule);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-library/issues/8971
`McpSourceModifier` rewrote every service declaration in a document containing mcp tools, and re-emitted only methods with a registered `@mcp:Tool` annotation — everything else was silently dropped.

Only `mcp:Service` / `mcp:StreamableHttpService` register tool annotations, so any other service sharing the document lost methods:

- a plain `http:Service` failed to compile with `undefined method 'helper'`
- `mcp:AdvancedService` failed with `no implementation found for the method 'onCallTool'`
- `mcp:StreamableHttpAdvancedService` compiled cleanly and failed at runtime on every `tools/list` / `tools/call`

Guard the rewrite on `Utils.isMcpBasicService` so non-mcp and advanced services are left untouched.

## Tests

Runtime tests for a co-located `http:Service` and a co-located `mcp:StreamableHttpAdvancedService`. Both fail without the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restricted MCP source rewriting to basic MCP services, leaving non-MCP and advanced services unchanged.
- Preserved service methods without registered MCP tool annotations during document rewriting.
- Added regression tests for co-located HTTP, basic MCP, and advanced MCP services.
- Updated the changelog with the fix and related MCP service updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->